### PR TITLE
Markercleanup

### DIFF
--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -105,13 +105,13 @@ const getImageFromMarker = target => {
   var img = null;
   switch (target.state) {
     case "pending":
-      img = marker.markerImage;
+      img = marker.markerIcon;
       break;
     case "assigned":
-      img = marker.markerImageAssigned;
+      img = marker.markerIconAssigned;
       break;
     case "completed":
-      img = marker.markerImageDone;
+      img = marker.markerIconDone;
       break;
   }
   return img;

--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -83,44 +83,11 @@ const getMarkerPopup = (marker, target, portal) => {
 
 export const getPopupBodyWithType = (portal, target) => {
   var title = "";
-  switch (target.type) {
-    case Wasabee.Constants.MARKER_TYPE_DECAY:
-      title = "Let Decay";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_DESTROY:
-      title = "Destroy";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_FARM:
-      title = "Farm";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_GOTO:
-      title = "Go To";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_KEY:
-      title = "Get Keys";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_LINK:
-      title = "Establish Link";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_MEETAGENT:
-      title = "Meet agent";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_OTHER:
-      title = "Other";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_RECHARGE:
-      title = "Recharge";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_UPGRADE:
-      title = "Upgrade";
-      break;
-    case Wasabee.Constants.MARKER_TYPE_VIRUS:
-      title = "Virus";
-      break;
-    default:
-      title = "Unknown";
+  if (!Wasabee.markerTypes.has(target.type)) {
+    target.type = Wasabee.Constants.DEFAULT_ALERT_TYPE;
   }
-  title = title + " - " + portal.name;
+  var marker = Wasabee.markerTypes.has(target.type);
+  title = marker.label + " - " + portal.name;
   if (target.comment) title = title + "\n\n" + target.comment;
   if (target.state != "completed" && target.assignedNickname)
     title = title + "\n\nAssigned To: " + target.assignedNickname;
@@ -129,89 +96,25 @@ export const getPopupBodyWithType = (portal, target) => {
   return title;
 };
 
-//** This function returns the appropriate image for a marker type */
+//** This function returns the appropriate image for a marker type / state */
 const getImageFromMarker = target => {
+  if (!Wasabee.markerTypes.has(target.type)) {
+    target.type = Wasabee.Constants.DEFAULT_ALERT_TYPE;
+  }
+  var img = Wasabee.static.images.marker_alert_other;
+  var marker = Wasabee.markerTypes.has(target.type);
   switch (target.state) {
     case "pending":
-      switch (target.type) {
-        case Wasabee.Constants.MARKER_TYPE_DECAY:
-          return Wasabee.static.images.marker_alert_decay;
-        case Wasabee.Constants.MARKER_TYPE_DESTROY:
-          return Wasabee.static.images.marker_alert_destroy;
-        case Wasabee.Constants.MARKER_TYPE_FARM:
-          return Wasabee.static.images.marker_alert_farm;
-        case Wasabee.Constants.MARKER_TYPE_GOTO:
-          return Wasabee.static.images.marker_alert_goto;
-        case Wasabee.Constants.MARKER_TYPE_KEY:
-          return Wasabee.static.images.marker_alert_key;
-        case Wasabee.Constants.MARKER_TYPE_LINK:
-          return Wasabee.static.images.marker_alert_link;
-        case Wasabee.Constants.MARKER_TYPE_MEETAGENT:
-          return Wasabee.static.images.marker_alert_meetagent;
-        case Wasabee.Constants.MARKER_TYPE_OTHER:
-          return Wasabee.static.images.marker_alert_other;
-        case Wasabee.Constants.MARKER_TYPE_RECHARGE:
-          return Wasabee.static.images.marker_alert_recharge;
-        case Wasabee.Constants.MARKER_TYPE_UPGRADE:
-          return Wasabee.static.images.marker_alert_upgrade;
-        case Wasabee.Constants.MARKER_TYPE_VIRUS:
-          return Wasabee.static.images.marker_alert_virus;
-      }
+      img = marker.markerImage;
       break;
     case "assigned":
-      switch (target.type) {
-        case Wasabee.Constants.MARKER_TYPE_DECAY:
-          return Wasabee.static.images.marker_alert_decay_assigned;
-        case Wasabee.Constants.MARKER_TYPE_DESTROY:
-          return Wasabee.static.images.marker_alert_destroy_assigned;
-        case Wasabee.Constants.MARKER_TYPE_FARM:
-          return Wasabee.static.images.marker_alert_farm_assigned;
-        case Wasabee.Constants.MARKER_TYPE_GOTO:
-          return Wasabee.static.images.marker_alert_goto_assigned;
-        case Wasabee.Constants.MARKER_TYPE_KEY:
-          return Wasabee.static.images.marker_alert_key_assigned;
-        case Wasabee.Constants.MARKER_TYPE_LINK:
-          return Wasabee.static.images.marker_alert_link_assigned;
-        case Wasabee.Constants.MARKER_TYPE_MEETAGENT:
-          return Wasabee.static.images.marker_alert_meetagent_assigned;
-        case Wasabee.Constants.MARKER_TYPE_OTHER:
-          return Wasabee.static.images.marker_alert_other_assigned;
-        case Wasabee.Constants.MARKER_TYPE_RECHARGE:
-          return Wasabee.static.images.marker_alert_recharge_assigned;
-        case Wasabee.Constants.MARKER_TYPE_UPGRADE:
-          return Wasabee.static.images.marker_alert_upgrade_assigned;
-        case Wasabee.Constants.MARKER_TYPE_VIRUS:
-          return Wasabee.static.images.marker_alert_virus_assigned;
-      }
+      img = marker.markerImageAssigned;
       break;
     case "completed":
-      switch (target.type) {
-        case Wasabee.Constants.MARKER_TYPE_DECAY:
-          return Wasabee.static.images.marker_alert_decay_done;
-        case Wasabee.Constants.MARKER_TYPE_DESTROY:
-          return Wasabee.static.images.marker_alert_destroy_done;
-        case Wasabee.Constants.MARKER_TYPE_FARM:
-          return Wasabee.static.images.marker_alert_farm_done;
-        case Wasabee.Constants.MARKER_TYPE_GOTO:
-          return Wasabee.static.images.marker_alert_goto_done;
-        case Wasabee.Constants.MARKER_TYPE_KEY:
-          return Wasabee.static.images.marker_alert_key_done;
-        case Wasabee.Constants.MARKER_TYPE_LINK:
-          return Wasabee.static.images.marker_alert_link_done;
-        case Wasabee.Constants.MARKER_TYPE_MEETAGENT:
-          return Wasabee.static.images.marker_alert_meetagent_done;
-        case Wasabee.Constants.MARKER_TYPE_OTHER:
-          return Wasabee.static.images.marker_alert_other_done;
-        case Wasabee.Constants.MARKER_TYPE_RECHARGE:
-          return Wasabee.static.images.marker_alert_recharge_done;
-        case Wasabee.Constants.MARKER_TYPE_UPGRADE:
-          return Wasabee.static.images.marker_alert_upgrade_done;
-        case Wasabee.Constants.MARKER_TYPE_VIRUS:
-          return Wasabee.static.images.marker_alert_virus_done;
-      }
+      img = marker.markerImageDone;
       break;
   }
-  return Wasabee.static.images.marker_alert_other;
+  return img;
 };
 
 //** This function adds all the Links to the layer */

--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -84,7 +84,7 @@ const getMarkerPopup = (marker, target, portal) => {
 export const getPopupBodyWithType = (portal, target) => {
   var title = "";
   if (!Wasabee.markerTypes.has(target.type)) {
-    target.type = Wasabee.Constants.DEFAULT_ALERT_TYPE;
+    target.type = Wasabee.Constants.DEFAULT_MARKER_TYPE;
   }
   var marker = Wasabee.markerTypes.has(target.type);
   title = marker.label + " - " + portal.name;
@@ -99,10 +99,10 @@ export const getPopupBodyWithType = (portal, target) => {
 //** This function returns the appropriate image for a marker type / state */
 const getImageFromMarker = target => {
   if (!Wasabee.markerTypes.has(target.type)) {
-    target.type = Wasabee.Constants.DEFAULT_ALERT_TYPE;
+    target.type = Wasabee.Constants.DEFAULT_MARKER_TYPE;
   }
-  var img = Wasabee.static.images.marker_alert_other;
-  var marker = Wasabee.markerTypes.has(target.type);
+  var marker = Wasabee.markerTypes.get(target.type);
+  var img = null;
   switch (target.state) {
     case "pending":
       img = marker.markerImage;

--- a/src/code/markerDialog.js
+++ b/src/code/markerDialog.js
@@ -30,10 +30,10 @@ export class MarkerDialog {
     this._target = null;
     this._operation = operation;
     this._type = $("<select>");
-    Wasabee.alertTypes.forEach(a => {
+    Wasabee.markerTypes.forEach((a, k) => {
       self._type.append(
         $("<option>")
-          .val(a.name)
+          .val(k)
           .text(a.label)
       );
     });

--- a/src/code/markerDialog.js
+++ b/src/code/markerDialog.js
@@ -37,7 +37,7 @@ export class MarkerDialog {
           .text(a.label)
       );
     });
-    this._type.val(Wasabee.Constants.DEFAULT_ALERT_TYPE);
+    this._type.val(Wasabee.Constants.DEFAULT_MARKER_TYPE);
     this._comment = $("<input>").attr("placeholder", "comment");
     /*  Uncomment this when adding specific targetting to agents
         this._agent = $('<select class="wasabee-agentselect"></select>').css({

--- a/src/code/scopes.js
+++ b/src/code/scopes.js
@@ -26,74 +26,142 @@ export default function() {
     SCRIPT_URL_NOTY: "http/://wasabee.rocks/wasabee_extras/noty.js"
   };
 
-  Wasabee.alertTypes = [
-    {
-      name: Wasabee.Constants.MARKER_TYPE_DECAY,
-      label: "let decay",
-      color: "#7D7D7D",
-      markerIcon: Wasabee.static.images.marker_alert_decay
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_DESTROY,
-      label: "destroy",
-      color: "#CE3B37",
-      markerIcon: Wasabee.static.images.marker_alert_destroy
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_FARM,
-      label: "farm",
-      color: "#CE3B37",
-      markerIcon: Wasabee.static.images.marker_alert_farm
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_GOTO,
-      label: "go to",
-      color: "#EDA032",
-      markerIcon: Wasabee.static.images.marker_alert_goto
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_KEY,
-      label: "get keys",
-      color: "#7D7D7D",
-      markerIcon: Wasabee.static.images.marker_alert_key
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_LINK,
-      label: "link",
-      color: "#5994FF",
-      markerIcon: Wasabee.static.images.marker_alert_link
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_MEETAGENT,
-      label: "meet agent",
-      color: "#EDA032",
-      markerIcon: Wasabee.static.images.marker_alert_meetagent
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_OTHER,
-      label: "other",
-      color: "#3679B4",
-      markerIcon: Wasabee.static.images.marker_alert_other
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_RECHARGE,
-      label: "recharge",
-      color: "#53AD53",
-      markerIcon: Wasabee.static.images.marker_alert_recharge
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_UPGRADE,
-      label: "upgrade",
-      color: "#448800",
-      markerIcon: Wasabee.static.images.marker_alert_upgrade
-    },
-    {
-      name: Wasabee.Constants.MARKER_TYPE_VIRUS,
-      label: "use virus",
-      color: "#8920C3",
-      markerIcon: Wasabee.static.images.marker_alert_virus
-    }
-  ];
+  Wasabee.markerTypes = new Map([
+    [
+      Wasabee.Constants.MARKER_TYPE_DECAY,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_DECAY,
+        label: "let decay",
+        color: "#7D7D7D",
+        markerIcon: Wasabee.static.images.marker_alert_decay,
+        markerIconAssigned: Wasabee.static.images.marker_alert_decay_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_decay_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_DESTROY,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_DESTROY,
+        label: "destroy",
+        color: "#CE3B37",
+        markerIcon: Wasabee.static.images.marker_alert_destroy,
+        markerIconAssigned: Wasabee.static.images.marker_alert_destroy_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_destroy_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_FARM,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_FARM,
+        label: "farm",
+        color: "#CE3B37",
+        markerIcon: Wasabee.static.images.marker_alert_farm,
+        markerIconAssigned: Wasabee.static.images.marker_alert_farm_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_farm_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_GOTO,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_GOTO,
+        label: "go to",
+        color: "#EDA032",
+        markerIcon: Wasabee.static.images.marker_alert_goto,
+        markerIconAssigned: Wasabee.static.images.marker_alert_goto_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_goto_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_KEY,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_KEY,
+        label: "get keys",
+        color: "#7D7D7D",
+        markerIcon: Wasabee.static.images.marker_alert_key,
+        markerIconAssigned: Wasabee.static.images.marker_alert_key_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_key_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_LINK,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_LINK,
+        label: "link",
+        color: "#5994FF",
+        markerIcon: Wasabee.static.images.marker_alert_link,
+        markerIconAssigned: Wasabee.static.images.marker_alert_link_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_link_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_MEETAGENT,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_MEETAGENT,
+        label: "meet agent",
+        color: "#EDA032",
+        markerIcon: Wasabee.static.images.marker_alert_meetagent,
+        markerIconAssigned:
+          Wasabee.static.images.marker_alert_meetagent_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_meetagent_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_OTHER,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_OTHER,
+        label: "other",
+        color: "#3679B4",
+        markerIcon: Wasabee.static.images.marker_alert_other,
+        markerIconAssigned: Wasabee.static.images.marker_alert_other_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_other_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_RECHARGE,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_RECHARGE,
+        label: "recharge",
+        color: "#53AD53",
+        markerIcon: Wasabee.static.images.marker_alert_recharge,
+        markerIconAssigned:
+          Wasabee.static.images.marker_alert_recharge_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_recharge_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_UPGRADE,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_UPGRADE,
+        label: "upgrade",
+        color: "#448800",
+        markerIcon: Wasabee.static.images.marker_alert_upgrade,
+        markerIconAssigned: Wasabee.static.images.marker_alert_upgrade_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_upgrade_done
+      }
+    ],
+    [
+      Wasabee.Constants.MARKER_TYPE_VIRUS,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_VIRUS,
+        label: "use virus",
+        color: "#8920C3",
+        markerIcon: Wasabee.static.images.marker_alert_virus,
+        markerIconAssigned: Wasabee.static.images.marker_alert_virus_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_virus_done
+      }
+    ],
+    [
+      Wasabee.Constants.DEFAULT_ALERT_TYPE,
+      {
+        name: Wasabee.Constants.MARKER_TYPE_OTHER,
+        label: "unknown",
+        color: "#8920C3",
+        markerIcon: Wasabee.static.images.marker_alert_other,
+        markerIconAssigned: Wasabee.static.images.marker_alert_other_assigned,
+        markerIconDone: Wasabee.static.images.marker_alert_other_done
+      }
+    ]
+  ]);
 
   Wasabee.layerTypes = [
     {

--- a/src/code/scopes.js
+++ b/src/code/scopes.js
@@ -18,12 +18,12 @@ export default function() {
     MARKER_TYPE_RECHARGE: "RechargePortalAlert",
     MARKER_TYPE_UPGRADE: "UpgradePortalAlert",
     MARKER_TYPE_VIRUS: "UseVirusPortalAlert",
-    DEFAULT_ALERT_TYPE: "OtherPortalAlert",
+    DEFAULT_MARKER_TYPE: "OtherPortalAlert",
     BREAK_EXCEPTION: {},
     OP_RESTRUCTURE_KEY: "OP_RESTRUCTURE_KEY22",
     SERVER_OP_LIST_KEY: "SERVER_OP_LIST_KEY",
     SERVER_OWNED_OP_LIST_KEY: "SERVER_OWNED_OP_LIST_KEY",
-    SCRIPT_URL_NOTY: "http/://wasabee.rocks/wasabee_extras/noty.js"
+    SCRIPT_URL_NOTY: "http://wasabee.rocks/wasabee_extras/noty.js"
   };
 
   Wasabee.markerTypes = new Map([
@@ -33,9 +33,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_DECAY,
         label: "let decay",
         color: "#7D7D7D",
-        markerIcon: Wasabee.static.images.marker_alert_decay,
-        markerIconAssigned: Wasabee.static.images.marker_alert_decay_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_decay_done
+        markerIcon: require("./images/wasabee_markers_decay_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_decay_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_decay_done.png")
       }
     ],
     [
@@ -44,9 +44,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_DESTROY,
         label: "destroy",
         color: "#CE3B37",
-        markerIcon: Wasabee.static.images.marker_alert_destroy,
-        markerIconAssigned: Wasabee.static.images.marker_alert_destroy_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_destroy_done
+        markerIcon: require("./images/wasabee_markers_destroy_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_destroy_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_destroy_done.png")
       }
     ],
     [
@@ -55,9 +55,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_FARM,
         label: "farm",
         color: "#CE3B37",
-        markerIcon: Wasabee.static.images.marker_alert_farm,
-        markerIconAssigned: Wasabee.static.images.marker_alert_farm_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_farm_done
+        markerIcon: require("./images/wasabee_markers_farm_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_farm_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_farm_done.png")
       }
     ],
     [
@@ -66,9 +66,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_GOTO,
         label: "go to",
         color: "#EDA032",
-        markerIcon: Wasabee.static.images.marker_alert_goto,
-        markerIconAssigned: Wasabee.static.images.marker_alert_goto_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_goto_done
+        markerIcon: require("./images/wasabee_markers_goto_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_goto_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_goto_done.png")
       }
     ],
     [
@@ -77,9 +77,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_KEY,
         label: "get keys",
         color: "#7D7D7D",
-        markerIcon: Wasabee.static.images.marker_alert_key,
-        markerIconAssigned: Wasabee.static.images.marker_alert_key_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_key_done
+        markerIcon: require("./images/wasabee_markers_key_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_key_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_key_done.png")
       }
     ],
     [
@@ -88,21 +88,21 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_LINK,
         label: "link",
         color: "#5994FF",
-        markerIcon: Wasabee.static.images.marker_alert_link,
-        markerIconAssigned: Wasabee.static.images.marker_alert_link_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_link_done
+        markerIcon: require("./images/wasabee_markers_link_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_link_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_link_done.png")
       }
     ],
+
     [
       Wasabee.Constants.MARKER_TYPE_MEETAGENT,
       {
         name: Wasabee.Constants.MARKER_TYPE_MEETAGENT,
         label: "meet agent",
         color: "#EDA032",
-        markerIcon: Wasabee.static.images.marker_alert_meetagent,
-        markerIconAssigned:
-          Wasabee.static.images.marker_alert_meetagent_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_meetagent_done
+        markerIcon: require("./images/wasabee_markers_meetagent_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_meetagent_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_meetagent_done.png")
       }
     ],
     [
@@ -111,9 +111,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_OTHER,
         label: "other",
         color: "#3679B4",
-        markerIcon: Wasabee.static.images.marker_alert_other,
-        markerIconAssigned: Wasabee.static.images.marker_alert_other_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_other_done
+        markerIcon: require("./images/wasabee_markers_other_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_other_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_other_done.png")
       }
     ],
     [
@@ -122,10 +122,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_RECHARGE,
         label: "recharge",
         color: "#53AD53",
-        markerIcon: Wasabee.static.images.marker_alert_recharge,
-        markerIconAssigned:
-          Wasabee.static.images.marker_alert_recharge_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_recharge_done
+        markerIcon: require("./images/wasabee_markers_recharge_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_recharge_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_recharge_done.png")
       }
     ],
     [
@@ -134,9 +133,9 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_UPGRADE,
         label: "upgrade",
         color: "#448800",
-        markerIcon: Wasabee.static.images.marker_alert_upgrade,
-        markerIconAssigned: Wasabee.static.images.marker_alert_upgrade_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_upgrade_done
+        markerIcon: require("./images/wasabee_markers_farm_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_farm_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_farm_done.png")
       }
     ],
     [
@@ -145,20 +144,20 @@ export default function() {
         name: Wasabee.Constants.MARKER_TYPE_VIRUS,
         label: "use virus",
         color: "#8920C3",
-        markerIcon: Wasabee.static.images.marker_alert_virus,
-        markerIconAssigned: Wasabee.static.images.marker_alert_virus_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_virus_done
+        markerIcon: require("./images/wasabee_markers_virus_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_virus_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_virus_done.png")
       }
     ],
     [
-      Wasabee.Constants.DEFAULT_ALERT_TYPE,
+      Wasabee.Constants.DEFAULT_MARKER_TYPE,
       {
         name: Wasabee.Constants.MARKER_TYPE_OTHER,
         label: "unknown",
         color: "#8920C3",
-        markerIcon: Wasabee.static.images.marker_alert_other,
-        markerIconAssigned: Wasabee.static.images.marker_alert_other_assigned,
-        markerIconDone: Wasabee.static.images.marker_alert_other_done
+        markerIcon: require("./images/wasabee_markers_other_pending.png"),
+        markerIconAssigned: require("./images/wasabee_markers_other_assigned.png"),
+        markerIconDone: require("./images/wasabee_markers_other_done.png")
       }
     ]
   ]);

--- a/src/code/static.js
+++ b/src/code/static.js
@@ -27,43 +27,7 @@ Wasabee.static = {
     marker_layer_groupc: require("./images/marker_layer_groupc.png"),
     marker_layer_groupd: require("./images/marker_layer_groupd.png"),
     marker_layer_groupe: require("./images/marker_layer_groupe.png"),
-    marker_layer_groupf: require("./images/marker_layer_groupf.png"),
-
-    marker_alert_decay: require("./images/wasabee_markers_decay_pending.png"),
-    marker_alert_destroy: require("./images/wasabee_markers_destroy_pending.png"),
-    marker_alert_farm: require("./images/wasabee_markers_farm_pending.png"),
-    marker_alert_goto: require("./images/wasabee_markers_goto_pending.png"),
-    marker_alert_key: require("./images/wasabee_markers_key_pending.png"),
-    marker_alert_link: require("./images/wasabee_markers_link_pending.png"),
-    marker_alert_meetagent: require("./images/wasabee_markers_meetagent_pending.png"),
-    marker_alert_other: require("./images/wasabee_markers_other_pending.png"),
-    marker_alert_recharge: require("./images/wasabee_markers_recharge_pending.png"),
-    marker_alert_upgrade: require("./images/wasabee_markers_farm_pending.png"),
-    marker_alert_virus: require("./images/wasabee_markers_virus_pending.png"),
-
-    marker_alert_decay_assigned: require("./images/wasabee_markers_decay_assigned.png"),
-    marker_alert_destroy_assigned: require("./images/wasabee_markers_destroy_assigned.png"),
-    marker_alert_farm_assigned: require("./images/wasabee_markers_farm_assigned.png"),
-    marker_alert_goto_assigned: require("./images/wasabee_markers_goto_assigned.png"),
-    marker_alert_key_assigned: require("./images/wasabee_markers_key_assigned.png"),
-    marker_alert_link_assigned: require("./images/wasabee_markers_link_assigned.png"),
-    marker_alert_meetagent_assigned: require("./images/wasabee_markers_meetagent_assigned.png"),
-    marker_alert_other_assigned: require("./images/wasabee_markers_other_assigned.png"),
-    marker_alert_recharge_assigned: require("./images/wasabee_markers_recharge_assigned.png"),
-    marker_alert_upgrade_assigned: require("./images/wasabee_markers_farm_assigned.png"),
-    marker_alert_virus_assigned: require("./images/wasabee_markers_virus_assigned.png"),
-
-    marker_alert_decay_done: require("./images/wasabee_markers_decay_done.png"),
-    marker_alert_destroy_done: require("./images/wasabee_markers_destroy_done.png"),
-    marker_alert_farm_done: require("./images/wasabee_markers_farm_done.png"),
-    marker_alert_goto_done: require("./images/wasabee_markers_goto_done.png"),
-    marker_alert_key_done: require("./images/wasabee_markers_key_done.png"),
-    marker_alert_link_done: require("./images/wasabee_markers_link_done.png"),
-    marker_alert_meetagent_done: require("./images/wasabee_markers_meetagent_done.png"),
-    marker_alert_other_done: require("./images/wasabee_markers_other_done.png"),
-    marker_alert_recharge_done: require("./images/wasabee_markers_recharge_done.png"),
-    marker_alert_upgrade_done: require("./images/wasabee_markers_farm_done.png"),
-    marker_alert_virus_done: require("./images/wasabee_markers_virus_done.png")
+    marker_layer_groupf: require("./images/marker_layer_groupf.png")
   }
   // Other static data, like: LocalStorage keys, encoded images, texts etc.
 };


### PR DESCRIPTION
This moves all the data about marker types into one single map and accesses that data cleanly.

I'd still like to sweep through and remove all the alert/target language, but this makes that cleanup much easier.

Test build here: https://server.wasabee.rocks/static/dev/markertest.user.js