### PR TITLE
Fix import dialog

### DIFF
--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -28,19 +28,36 @@ const ImportDialogControl = WDialog.extend({
 
   _displayDialog: function() {
     if (!this._map) return;
-    this.idialog = new ImportDialog();
+
+    const container = L.DomUtil.create("div", null);
+    container.style.width = "420px";
+
+    const nameblock = L.DomUtil.create("span", null, container);
+    const label = L.DomUtil.create("label", null, nameblock);
+    label.textContent = wX("NAME");
+    this._namefield = L.DomUtil.create("input", null, label);
+    this._namefield.value = wX("IMPORT_OP") + new Date().toGMTString();
+    this._namefield.placeholder = "noodles";
+    // this._namefield.width = 16;
+    const note = L.DomUtil.create("span", null, nameblock);
+    note.textContent = wX("ONLY_DT_IMP");
+
+    // Input area
+    this._textarea = L.DomUtil.create("textarea", null, container);
+    this._textarea.placeholder = wX("PASTE_INSTRUCT");
+
     this._dialog = window.dialog({
       title: wX("IMP_WAS_OP"),
       width: "auto",
       height: "auto",
-      html: this.idialog.container,
+      html: container,
       buttons: {
         OK: () => {
-          this.idialog.importTextareaAsOp();
+          this.importTextareaAsOp();
           this._dialog.dialog("close");
         },
         "Get existing DrawTools draw": () => {
-          this.idialog.drawToolsFormat();
+          this.drawToolsFormat();
         }
       },
       dialogClass: "wasabee-dialog wasabee-dialog-import",
@@ -53,31 +70,7 @@ const ImportDialogControl = WDialog.extend({
       },
       id: window.plugin.wasabee.static.dialogNames.importDialog
     });
-  }
-});
-
-export default ImportDialogControl;
-
-// XXX move all this into the main class, no need for a sub class for this
-class ImportDialog {
-  constructor() {
-    this.container = L.DomUtil.create("div", null);
-    this.container.style.width = "420px";
-
-    const nameblock = L.DomUtil.create("span", null, this.container);
-    const label = L.DomUtil.create("label", null, nameblock);
-    label.textContent = wX("NAME");
-    this._namefield = L.DomUtil.create("input", null, label);
-    this._namefield.value = wX("IMPORT_OP") + new Date().toGMTString();
-    this._namefield.placeholder = "noodles";
-    // this._namefield.width = 16;
-    const note = L.DomUtil.create("span", null, nameblock);
-    note.textContent = wX("ONLY_DT_IMP");
-
-    // Input area
-    this.textarea = L.DomUtil.create("textarea", null, this.container);
-    this.textarea.placeholder = wX("PASTE_INSTRUCT");
-  }
+  },
 
   drawToolsFormat() {
     if (window.plugin.drawTools.drawnItems) {
@@ -86,15 +79,15 @@ class ImportDialog {
         if (layer instanceof L.GeodesicPolyline || layer instanceof L.Polyline) {
 	}
       } */
-      // this.textarea.value = JSON.stringify(tmp);
-      this.textarea.value = localStorage["plugin-draw-tools-layer"];
+      // this._textarea.value = JSON.stringify(tmp);
+      this._textarea.value = localStorage["plugin-draw-tools-layer"];
     } else {
-      this.textarea.placeholder = wX("NO_DT_ITEMS");
+      this._textarea.placeholder = wX("NO_DT_ITEMS");
     }
-  }
+  },
 
   importTextareaAsOp() {
-    const string = this.textarea.value;
+    const string = this._textarea.value;
     if (
       string.match(
         new RegExp("^(https?://)?(www\\.)?intel.ingress.com/intel.*")
@@ -107,6 +100,7 @@ class ImportDialog {
     // check to see if it is drawtools
     if (string.match(new RegExp(".*polyline.*"))) {
       console.log("trying to import IITC Drawtools format... wish me luck");
+
       const newop = this.parseDrawTools(string);
       newop.updatePortalsFromIITCData();
       if (this._namefield.value) {
@@ -133,7 +127,7 @@ class ImportDialog {
       console.warn("WasabeeTools: failed to import data: " + e);
       alert(wX("IMP_NOPE"));
     }
-  }
+  },
 
   parseDrawTools(string) {
     const newop = new WasabeeOp();
@@ -194,7 +188,7 @@ class ImportDialog {
       wX("IMP_COMP") + found + wX("PORT_FAKE") + faked + wX("USE_SWAP_INSTRUCT")
     );
     return newop;
-  }
+  },
 
   // build a fast lookup map of known portals
   buildWindowPortalMap() {
@@ -205,7 +199,7 @@ class ImportDialog {
       pmap.set(key, portalID);
     }
     return pmap;
-  }
+  },
 
   searchWindowPortals(latLng, pmap) {
     const key = latLng.lat + "/" + latLng.lng;
@@ -221,4 +215,6 @@ class ImportDialog {
     }
     return false;
   }
-}
+});
+
+export default ImportDialogControl;

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -5,14 +5,14 @@ import { getSelectedOperation, makeSelectedOperation } from "../selectedOp";
 import OperationChecklistDialog from "./operationChecklistDialog";
 import wX from "../wX";
 
-const ImportDialogControl = WDialog.extend({
+const ImportDialog = WDialog.extend({
   statics: {
     TYPE: "importDialog"
   },
 
   initialize: function(map, options) {
     if (!map) map = window.map;
-    this.type = ImportDialogControl.TYPE;
+    this.type = ImportDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
   },
 
@@ -217,4 +217,4 @@ const ImportDialogControl = WDialog.extend({
   }
 });
 
-export default ImportDialogControl;
+export default ImportDialog;

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -205,12 +205,7 @@ const ImportDialog = WDialog.extend({
     const key = latLng.lat + "/" + latLng.lng;
     if (pmap.has(key)) {
       const portalID = pmap.get(key);
-      const np = new WasabeePortal(
-        portalID,
-        wX("LOADING1") + portalID + wX("LOADING2"),
-        latLng.lat,
-        latLng.lng
-      );
+      const np = WasabeePortal.fake(latLng.lat, latLng.lng, portalID);
       return np;
     }
     return false;

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -137,6 +137,8 @@ class ImportDialog {
 
   parseDrawTools(string) {
     const newop = new WasabeeOp();
+    // Don't check crosslink
+    newop.startBatchMode();
     newop.name = wX("IMP_DT_OP") + new Date().toGMTString();
     const data = JSON.parse(string);
 

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -1,6 +1,6 @@
 import { WDialog } from "../leafletClasses";
 import WasabeeOp from "../operation";
-import ImportDialogControl from "./importDialog";
+import ImportDialog from "./importDialog";
 import PromptDialog from "./promptDialog";
 import { makeSelectedOperation } from "../selectedOp";
 import wX from "../wX";
@@ -33,7 +33,7 @@ const NewopDialog = WDialog.extend({
     L.DomEvent.on(importButton, "click", ev => {
       L.DomEvent.stop(ev);
       noHandler._dialog.dialog("close");
-      const id = new ImportDialogControl(this._map, null);
+      const id = new ImportDialog(this._map, null);
       id.enable();
     });
 


### PR DESCRIPTION
atm, the import throw error because it check crosslink while importing but the crosslink test is made using the selected operation while the link is in another operation.

The fusion of ImportDialog and ImportDialogControl also fix an error about this._map being null.
