### PR TITLE
don't check VALID_HOOK on recent iitc build

### DIFF
--- a/src/code/init.js
+++ b/src/code/init.js
@@ -19,8 +19,14 @@ window.plugin.wasabee.init = function() {
 
   if (window.plugin.sync) alert(wX("DISABLE_SYNC"));
 
+  // check if using 'old' iitc
+  const hookLength = window.VALID_HOOKS.hookLength;
+  Wasabee.usingOldIITC = false;
+
   // no longer necessary on IITC-CE, but still needed on 0.26
   window.pluginCreateHook("wasabeeUIUpdate");
+
+  if (window.VALID_HOOKS.hookLength > hookLength) Wasabee.usingOldIITC = true;
 
   Wasabee._selectedOp = null; // the in-memory working op;
   Wasabee.teams = new Map();
@@ -101,7 +107,7 @@ window.plugin.wasabee.init = function() {
   window.runHooks("wasabeeUIUpdate", Wasabee._selectedOp);
 
   // run crosslinks
-  if (window.VALID_HOOKS.includes("wasabeeCrosslinks"))
+  if (!Wasabee.usingOldIITC || window.VALID_HOOKS.includes("wasabeeCrosslinks"))
     window.runHooks("wasabeeCrosslinks", Wasabee._selectedOp);
 
   // if the browser was restarted and the cookie nuked, but localstorge[me]
@@ -112,7 +118,7 @@ window.plugin.wasabee.init = function() {
     WasabeeMe.get(true);
   }
 
-  if (window.VALID_HOOKS.includes("wasabeeDkeys"))
+  if (!Wasabee.usingOldIITC || window.VALID_HOOKS.includes("wasabeeDkeys"))
     window.runHooks("wasabeeDkeys");
 };
 

--- a/src/code/selectedOp.js
+++ b/src/code/selectedOp.js
@@ -74,9 +74,15 @@ export const makeSelectedOperation = opID => {
   // redraw the screen, old version of IITC might not have set the hooks up yet
   // so make sure the hooks are there
   // VALID_HOOKS seems to be empty now?
-  if (window.VALID_HOOKS.includes("wasabeeUIUpdate"))
+  if (
+    !window.plugin.wasabee.usingOldIITC ||
+    window.VALID_HOOKS.includes("wasabeeUIUpdate")
+  )
     window.runHooks("wasabeeUIUpdate", window.plugin.wasabee._selectedOp);
-  if (window.VALID_HOOKS.includes("wasabeeCrosslinks"))
+  if (
+    !window.plugin.wasabee.usingOldIITC ||
+    window.VALID_HOOKS.includes("wasabeeCrosslinks")
+  )
     window.runHooks("wasabeeCrosslinks", window.plugin.wasabee._selectedOp);
   return window.plugin.wasabee._selectedOp;
 };


### PR DESCRIPTION
this fix a small side effect when using makeSelectedOperation, on recent iitc build, the hooks are not called. (until something triggers a redraw)
