### PR TITLE
operation: lookup tables for portals

### DIFF
--- a/src/code/crosslinks.js
+++ b/src/code/crosslinks.js
@@ -230,10 +230,7 @@ const testLink = (link, operation) => {
           (link.options.data.oLngE6 / 1e6).toFixed(6),
           link.options.data.oGuid
         );
-      if (!operation.containsPortal(fromPortal)) {
-        // saves one call to op.update();
-        operation.opportals.push(fromPortal);
-      }
+      operation._addPortal(fromPortal);
       let toPortal = WasabeePortal.get(link.options.data.dGuid);
       if (!toPortal)
         toPortal = WasabeePortal.fake(
@@ -241,10 +238,7 @@ const testLink = (link, operation) => {
           (link.options.data.dLngE6 / 1e6).toFixed(6),
           link.options.data.dGuid
         );
-      if (!operation.containsPortal(toPortal)) {
-        // saves one call to op.update();
-        operation.opportals.push(toPortal);
-      }
+      operation._addPortal(toPortal);
       const blocker = new WasabeeLink(operation, fromPortal.id, toPortal.id);
       operation.addBlocker(blocker); // op.update() is called here
       break;

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -174,10 +174,10 @@ const ImportDialog = WDialog.extend({
 
       for (const point of line.latLngs) {
         // use fixed precision
-        const truncPoint = new L.LatLng(
-          parseFloat(point.lat.toFixed(6)),
-          parseFloat(point.lng.toFixed(6))
-        );
+        const truncPoint = {
+          lat: point.lat.toFixed(6),
+          lng: point.lng.toFixed(6)
+        };
         // check the op first
         let portal = newop.getPortalByLatLng(truncPoint.lat, truncPoint.lng);
 
@@ -248,7 +248,7 @@ const ImportDialog = WDialog.extend({
     const pmap = new Map();
     for (const portalID in window.portals) {
       const ll = window.portals[portalID].getLatLng();
-      const key = ll.lat + "/" + ll.lng;
+      const key = ll.lat.toFixed(6) + "/" + ll.lng.toFixed(6);
       pmap.set(key, portalID);
     }
     return pmap;

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -223,7 +223,7 @@ const ImportDialog = WDialog.extend({
     const promises = new Array();
 
     for (const p of op.fakedPortals) {
-      if (p.id.length != 35) continue; // ignore the truly fake
+      if (p.pureFaked) continue; // ignore the truly fake
       promises.push(
         window.portalDetail.request(p.id).then(
           res => {

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -6,7 +6,7 @@ import addButtons from "./addButtons";
 import { setupToolbox } from "./toolbox";
 import { initFirebase } from "./firebaseSupport";
 import { initWasabeeD } from "./wd";
-import { sendLocation } from "./uiCommands";
+import { listenForPortalDetails, sendLocation } from "./uiCommands";
 import wX from "./wX";
 import WasabeeMe from "./me";
 const Wasabee = window.plugin.wasabee;
@@ -52,6 +52,14 @@ window.plugin.wasabee.init = function() {
   // standard hook, add our call to it
   window.addHook("mapDataRefreshStart", () => {
     drawAgents(Wasabee._selectedOp);
+  });
+
+  window.addHook("portalDetailsUpdated", e => {
+    listenForPortalDetails({
+      success: true,
+      guid: e.guid,
+      details: e.portalDetails
+    });
   });
 
   // custom hook for updating our UI

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -79,13 +79,13 @@ export default class WasabeeOp {
       }
     }
 
-    if (!this._dirtyCoordsTable) {
+    if (this._dirtyCoordsTable) {
       const toRemove = new Array();
       const rename = new Map();
 
       for (const [id, p] of this._idToOpportals) {
         const key = p.lat + "/" + p.lng;
-        const preferredPortal = this._idToOpportals(
+        const preferredPortal = this._idToOpportals.get(
           this._coordsToOpportals.get(key).id
         );
         rename.set(id, preferredPortal.id);
@@ -353,8 +353,6 @@ export default class WasabeeOp {
 
     this._idToOpportals = newPortals;
     this.buildCoordsLookupTable();
-
-    this.opportals = Array.from(this._idToOpportals.values());
   }
 
   addPortal(portal) {
@@ -512,11 +510,6 @@ export default class WasabeeOp {
   }
 
   swapPortal(originalPortal, newPortal) {
-    const oldkey = originalPortal.lat + "/" + originalPortal.lng;
-
-    this._idToOpportals.delete(originalPortal.id);
-    this._coordsToOpportals.delete(oldkey);
-
     this._addPortal(newPortal);
 
     this.opportals = Array.from(this._idToOpportals.values());
@@ -833,7 +826,7 @@ export default class WasabeeOp {
     // if (!operation.teamlist) operation.teamlist = new Array();
     // if (!operation.keysonhand) operation.keysonhand = new Array()
 
-    for (const p of operation.opportals) this._idToOpportals.set(p.id, p);
+    for (const p of operation.opportals) operation._idToOpportals.set(p.id, p);
     operation.buildCoordsLookupTable();
 
     operation.cleanAnchorList();

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -20,7 +20,7 @@ export default class WasabeeOp {
     this.ID = generateId();
     this.name = name;
     this.creator = creator;
-    this.opportals = Array();
+    //this.opportals = Array();
     this.anchors = Array();
     this.links = Array();
     this.markers = Array();
@@ -49,7 +49,7 @@ export default class WasabeeOp {
       ID: this.ID,
       name: this.name,
       creator: this.creator,
-      opportals: this.opportals,
+      opportals: Array.from(this._idToOpportals.values()),
       anchors: this.anchors,
       links: this.links,
       markers: this.markers,
@@ -62,6 +62,11 @@ export default class WasabeeOp {
       blockers: this.blockers,
       keysonhand: this.keysonhand
     };
+  }
+
+  // read only (for inspection)
+  get opportals() {
+    return Array.from(this._idToOpportals.values());
   }
 
   buildCoordsLookupTable() {
@@ -119,7 +124,7 @@ export default class WasabeeOp {
 
       for (const id of toRemove) this._idToOpportals.delete(id);
 
-      this.opportals = Array.from(this._idToOpportals.values());
+      //this.opportals = Array.from(this._idToOpportals.values());
     }
 
     this._dirtyCoordsTable = false;
@@ -383,7 +388,7 @@ export default class WasabeeOp {
       }
       this._idToOpportals.set(portal.id, portal);
       this._coordsToOpportals.set(key, portal);
-      this.opportals.push(portal);
+      //this.opportals.push(portal);
       return true;
     }
     return false;
@@ -428,7 +433,7 @@ export default class WasabeeOp {
         }
         this._idToOpportals.delete(old.id);
 
-        this.opportals = Array.from(this._idToOpportals.values());
+        //this.opportals = Array.from(this._idToOpportals.values());
 
         // NB: truly faked portal are anchors only so we can delete them if swaped
         return true;
@@ -516,7 +521,7 @@ export default class WasabeeOp {
   }
 
   get fakedPortals() {
-    const c = this.opportals.filter(p => p.faked);
+    const c = Array.from(this._idToOpportals.values()).filter(p => p.faked);
     return c;
   }
 
@@ -571,7 +576,7 @@ export default class WasabeeOp {
   swapPortal(originalPortal, newPortal) {
     this._addPortal(newPortal);
 
-    this.opportals = Array.from(this._idToOpportals.values());
+    //this.opportals = Array.from(this._idToOpportals.values());
 
     this._swapPortal(originalPortal, newPortal);
     this.update(true);
@@ -609,7 +614,7 @@ export default class WasabeeOp {
   }
 
   clearAllItems() {
-    this.opportals = Array();
+    //this.opportals = Array();
     this.anchors = Array();
     this.links = Array();
     this.markers = Array();
@@ -761,10 +766,10 @@ export default class WasabeeOp {
 
   // minimum bounds rectangle
   get mbr() {
-    if (!this.opportals || this.opportals.length == 0) return null;
+    if (this._idToOpportals.size == 0) return null;
     const lats = [];
     const lngs = [];
-    for (const a of this.opportals) {
+    for (const a of this._idToOpportals.values()) {
       lats.push(a.lat);
       lngs.push(a.lng);
     }
@@ -865,7 +870,7 @@ export default class WasabeeOp {
     }
     const operation = new WasabeeOp(obj.creator, obj.name);
     if (obj.ID) operation.ID = obj.ID;
-    operation.opportals = operation.convertPortalsToObjs(obj.opportals);
+    const opportals = operation.convertPortalsToObjs(obj.opportals);
     operation.anchors = obj.anchors ? obj.anchors : Array();
     operation.links = operation.convertLinksToObjs(obj.links);
     operation.markers = operation.convertMarkersToObjs(obj.markers);
@@ -878,14 +883,15 @@ export default class WasabeeOp {
     operation.blockers = operation.convertBlockersToObjs(obj.blockers);
     operation.keysonhand = obj.keysonhand ? obj.keysonhand : Array();
 
-    if (!operation.opportals) operation.opportals = new Array();
+    //if (!operation.opportals) operation.opportals = new Array();
     if (!operation.links) operation.links = new Array();
     if (!operation.markers) operation.markers = new Array();
     if (!operation.blockers) operation.blockers = new Array();
     // if (!operation.teamlist) operation.teamlist = new Array();
     // if (!operation.keysonhand) operation.keysonhand = new Array()
 
-    for (const p of operation.opportals) operation._idToOpportals.set(p.id, p);
+    if (opportals)
+      for (const p of opportals) operation._idToOpportals.set(p.id, p);
     operation.buildCoordsLookupTable();
 
     operation.cleanAnchorList();

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -81,19 +81,30 @@ export default class WasabeeOp {
 
     if (!this._dirtyCoordsTable) {
       const toRemove = new Array();
+      const rename = new Map();
 
       for (const [id, p] of this._idToOpportals) {
         const key = p.lat + "/" + p.lng;
         const preferredPortal = this._idToOpportals(
           this._coordsToOpportals.get(key).id
         );
+        rename.set(id, preferredPortal.id);
         if (id != preferredPortal.id) {
-          this._swapPortal(
-            p,
-            this._idToOpportals(this._coordsToOpportals.get(key).id)
-          );
           toRemove.push(id);
         }
+      }
+      // swap IDs
+      for (const l of this.links) {
+        l.fromPortalId = rename.get(l.fromPortalId);
+        l.toPortalId = rename.get(l.toPortalId);
+      }
+      for (const m of this.markers) {
+        m.portalId = rename.get(m.portalId);
+      }
+      this.anchors = this.anchors.map(a => rename.get(a));
+      for (const b of this.blockers) {
+        b.fromPortalId = rename.get(b.fromPortalId);
+        b.toPortalId = rename.get(b.toPortalId);
       }
 
       for (const id of toRemove) this._idToOpportals.delete(id);

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -427,6 +427,9 @@ export default class WasabeeOp {
           if (b.toPortalId == old.id) b.toPortalId = portal.id;
         }
         this._idToOpportals.delete(old.id);
+
+        this.opportals = Array.from(this._idToOpportals.values());
+
         // NB: truly faked portal are anchors only so we can delete them if swaped
         return true;
       }

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -354,18 +354,20 @@ export default class WasabeeOp {
   }
 
   _addPortal(portal) {
-    const key = portal.lat + "/" + portal.lng;
-    if (this._coordsToOpportals.has(key)) {
-      // the portal is likely to be a real portal while old is a faked one
-      // this is addressed later when rebuilding coords lookup table
-      console.log(
-        "try to add a portal at same coordinates of another, need cleaning at some point"
-      );
-      this._dirtyCoordsTable = true;
+    if (!this.containsPortal(portal)) {
+      const key = portal.lat + "/" + portal.lng;
+      if (this._coordsToOpportals.has(key)) {
+        // the portal is likely to be a real portal while old is a faked one
+        // this is addressed later when rebuilding coords lookup table
+        console.log(
+          "try to add a portal at same coordinates of another, need cleaning at some point"
+        );
+        this._dirtyCoordsTable = true;
+      }
+      this._idToOpportals.set(portal.id, portal);
+      this._coordsToOpportals.set(key, portal);
+      this.opportals.push(portal);
     }
-    this._idToOpportals.set(portal.id, portal);
-    this._coordsToOpportals.set(key, portal);
-    this.opportals.push(portal);
   }
 
   addLink(fromPortal, toPortal, description, order) {
@@ -409,9 +411,7 @@ export default class WasabeeOp {
 
   addAnchor(portal) {
     // doing this ourselves saves a trip to update();
-    if (!this.containsPortal(portal)) {
-      this._addPortal(portal);
-    }
+    this._addPortal(portal);
     if (!this.containsAnchor(portal.id)) {
       this.anchors.push(portal.id);
       this.update(true);
@@ -506,9 +506,7 @@ export default class WasabeeOp {
     this._idToOpportals.delete(originalPortal.id);
     this._coordsToOpportals.delete(oldkey);
 
-    if (!this.containsPortal(newPortal)) {
-      this._addPortal(newPortal);
-    }
+    this._addPortal(newPortal);
 
     this.opportals = Array.from(this._idToOpportals.values());
 

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -374,6 +374,28 @@ export default class WasabeeOp {
     }
   }
 
+  updatePortal(portal) {
+    const old = this.getPortal(portal.id);
+    if (old) {
+      if (!portal.faked) {
+        old.name = portal.name;
+        this.update(true);
+      }
+    } else {
+      const almostFaked = this.getPortalByLatLng(portal.lat, portal.lng);
+      if (almostFaked) {
+        if (almostFaked.pureFaked) {
+          this.swapPortal(almostFaked, portal);
+          this.update(true);
+        } else {
+          console.log(
+            "try to update a real portal at another one, what did you do?"
+          );
+        }
+      }
+    }
+  }
+
   addLink(fromPortal, toPortal, description, order) {
     if (!fromPortal || !toPortal) {
       console.log("missing portal for link");

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -476,7 +476,7 @@ export default class WasabeeOp {
   }
 
   get fakedPortals() {
-    const c = this.opportals.filter(p => p.name && p.name == p.id);
+    const c = this.opportals.filter(p => p.faked);
     return c;
   }
 

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -454,21 +454,11 @@ export default class WasabeeOp {
   }
 
   _swapPortal(originalPortal, newPortal) {
-    const oldkey = originalPortal.lat + "/" + originalPortal.lng;
-    const newkey = newPortal.lat + "/" + newPortal.lng;
-
-    this._idToOpportals.delete(originalPortal.id);
-    this._idToOpportals.set(newPortal.id, newPortal);
-
-    this._coordsToOpportals.delete(oldkey);
-    this._coordsToOpportals.set(newkey, newPortal);
-
-    this.opportals = Array.from(this._idToOpportals.values());
-
     this.anchors = this.anchors.filter(function(listAnchor) {
       return listAnchor !== originalPortal.id;
     });
     this.addAnchor(newPortal);
+
     const linksToRemove = [];
     for (const l of this.links) {
       // purge any crosslink check cache
@@ -511,6 +501,17 @@ export default class WasabeeOp {
   }
 
   swapPortal(originalPortal, newPortal) {
+    const oldkey = originalPortal.lat + "/" + originalPortal.lng;
+
+    this._idToOpportals.delete(originalPortal.id);
+    this._coordsToOpportals.delete(oldkey);
+
+    if (!this.containsPortal(newPortal)) {
+      this._addPortal(newPortal);
+    }
+
+    this.opportals = Array.from(this._idToOpportals.values());
+
     this._swapPortal(originalPortal, newPortal);
     this.update(true);
     this.runCrosslinks();

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -188,10 +188,7 @@ export default class WasabeeOp {
   }
 
   getPortal(portalID) {
-    for (const p of this.opportals) {
-      if (p.id == portalID) return p;
-    }
-    return null;
+    return this._idToOpportals.get(portalID);
   }
 
   removeAnchor(portalId) {
@@ -264,20 +261,18 @@ export default class WasabeeOp {
   }
 
   setPortalComment(portal, comment) {
-    for (const p of this.opportals) {
-      if (p.id == portal.id) {
-        p.comment = comment;
-        this.update(true);
-      }
+    const p = this.getPortal(portal.id);
+    if (p) {
+      p.comment = comment;
+      this.update(true);
     }
   }
 
   setPortalHardness(portal, hardness) {
-    for (const p of this.opportals) {
-      if (p.id == portal.id) {
-        p.hardness = hardness;
-        this.update(true);
-      }
+    const p = this.getPortal(portal.id);
+    if (p) {
+      p.hardness = hardness;
+      this.update(true);
     }
   }
 

--- a/src/code/portal.js
+++ b/src/code/portal.js
@@ -97,10 +97,8 @@ export default class WasabeePortal {
   }
 
   get displayName() {
-    if (this.id === this.name) {
-      if (this.id.length == 35) return wX("LOADING1", this.id);
-      return wX("FAKED", this.id);
-    }
+    if (this.pureFaked) return wX("FAKED", this.id);
+    if (this.loading) return wX("LOADING1", this.id);
     return this.name;
   }
 
@@ -161,6 +159,18 @@ export default class WasabeePortal {
     if (!name) name = id;
     const n = new WasabeePortal(id, name, lat, lng);
     return n;
+  }
+
+  get faked() {
+    return this.id.length != 35 || this.id == this.name;
+  }
+
+  get loading() {
+    return this.id.length == 35 && this.id == this.name;
+  }
+
+  get pureFaked() {
+    return this.id.length != 35;
   }
 
   static getSelected() {

--- a/src/code/uiCommands.js
+++ b/src/code/uiCommands.js
@@ -95,7 +95,7 @@ export const listenForPortalDetails = e => {
   if (!e.success) return;
   const op = getSelectedOperation();
   op.updatePortal(
-    WasabeePortal(
+    new WasabeePortal(
       e.guid,
       e.details.title,
       (e.details.latE6 / 1e6).toFixed(6),

--- a/src/code/uiCommands.js
+++ b/src/code/uiCommands.js
@@ -88,46 +88,20 @@ export const listenForAddedPortals = newPortal => {
   if (!newPortal.portal.options.data.title) return;
 
   const op = getSelectedOperation();
-
-  for (const faked of op.fakedPortals) {
-    // if we had a GUID -- normal faked
-    if (faked.id == newPortal.portal.options.guid) {
-      faked.name = newPortal.portal.options.data.title;
-      op.update(true);
-      return;
-    }
-
-    // if we only had location -- from drawtools import
-    if (
-      faked.lat == (newPortal.portal.options.data.latE6 / 1e6).toFixed(6) &&
-      faked.lng == (newPortal.portal.options.data.lngE6 / 1e6).toFixed(6)
-    ) {
-      const np = new WasabeePortal(
-        newPortal.portal.options.guid,
-        newPortal.portal.options.data.title,
-        (newPortal.portal.options.data.latE6 / 1e6).toFixed(6),
-        (newPortal.portal.options.data.lngE6 / 1e6).toFixed(6)
-      );
-
-      op.swapPortal(faked, np);
-      op.update(true);
-      // don't bail just yet, more may match
-    }
-  }
+  op.updatePortal(WasabeePortal.fromIITC(newPortal.portal));
 };
 
 export const listenForPortalDetails = e => {
   if (!e.success) return;
   const op = getSelectedOperation();
-
-  for (const faked of op.fakedPortals) {
-    if (faked.id == e.guid) {
-      faked.name = e.details.title;
-      op.update(true);
-      return;
-    }
-  }
-  // TODO listen for by location
+  op.updatePortal(
+    WasabeePortal(
+      e.guid,
+      e.details.title,
+      (e.details.latE6 / 1e6).toFixed(6),
+      (e.details.lngE6 / 1e6).toFixed(6)
+    )
+  );
 };
 
 // This is what should be called to add to the queue

--- a/src/code/uiCommands.js
+++ b/src/code/uiCommands.js
@@ -175,7 +175,7 @@ const pdqDoNext = function() {
     return;
   }
 
-  if (!p.length || p.length != 35) return; // ignore faked ones from DrawTools imports and other garbage
+  if (p.length != 35) return; // ignore faked ones from DrawTools imports and other garbage
   // this is the bit everyone is so worried about
   window.portalDetail.request(p);
 };


### PR DESCRIPTION
Use internally two maps (guid, latlng) instead of an array to managed operation portals.
While a map by guid is easy to handle, the map by coordinates may meet some conflict because of fake portals.

One of the changes is the introduction to `updatePortal` that try to update the data of an existent portal, or replace a portal at some coordinate by another with same coordinates.

Since some features do not need `update` call, the function `addPortal`, `updatePortal` and `swapPortal` get silent versions.

this PR looks a bit muddled to me (at least commit per commit) and need some review (on final diff)