### PR TITLE
assignDialog: fix link assignement

### DIFF
--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -52,35 +52,38 @@ const AssignDialog = WDialog.extend({
     this._targetID = target.ID;
     this._html = L.DomUtil.create("div", null);
     const divtitle = L.DomUtil.create("div", "desc", this._html);
+    const menu = this._getAgentMenu(target.assignedTo);
 
     if (target instanceof WasabeeLink) {
       const portal = operation.getPortal(target.fromPortalId);
       this._type = "Link";
-      divtitle.appendChild(target.displayFormat(operation, this._smallScreen));
-      const t = L.DomUtil.create("span", null, divtitle);
-      t.textContent = wX("LINK ASSIGNMENT");
       this._name = wX("ASSIGN LINK PROMPT", portal.displayName);
+      divtitle.appendChild(target.displayFormat(operation, this._smallScreen));
+      const t = L.DomUtil.create("label", null);
+      t.textContent = wX("LINK ASSIGNMENT");
+      menu.prepend(t);
     }
 
     if (target instanceof WasabeeMarker) {
       const portal = operation.getPortal(target.portalId);
       this._type = "Marker";
-      divtitle.appendChild(portal.displayFormat(this._smallScreen));
-      const t = L.DomUtil.create("span", null, divtitle);
-      t.textContent = wX("MARKER ASSIGNMENT");
       this._name = wX("ASSIGN MARKER PROMPT", portal.displayName);
+      divtitle.appendChild(portal.displayFormat(this._smallScreen));
+      const t = L.DomUtil.create("label", null);
+      t.textContent = wX("MARKER ASSIGNMENT");
+      menu.prepend(t);
     }
 
     if (target instanceof WasabeeAnchor) {
       const portal = operation.getPortal(target.portalId);
       this._type = "Anchor";
-      divtitle.appendChild(portal.displayFormat(this._smallScreen));
-      const t = L.DomUtil.create("span", null, divtitle);
-      t.textContent = wX("ANCHOR ASSIGNMENT");
       this._name = wX("ASSIGN OUTBOUND PROMPT", portal.displayName);
+      divtitle.appendChild(portal.displayFormat(this._smallScreen));
+      const t = L.DomUtil.create("label", null);
+      t.textContent = wX("ANCHOR ASSIGNMENT");
+      menu.prepend(t);
     }
 
-    const menu = this._getAgentMenu(target.assignedTo);
     this._html.appendChild(menu);
   },
 

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -56,7 +56,7 @@ const AssignDialog = WDialog.extend({
     if (target instanceof WasabeeLink) {
       const portal = operation.getPortal(target.fromPortalId);
       this._type = "Link";
-      divtitle.appendChild(target.displayFormat(this._smallScreen));
+      divtitle.appendChild(target.displayFormat(operation, this._smallScreen));
       const t = L.DomUtil.create("span", null, divtitle);
       t.textContent = wX("LINK ASSIGNMENT");
       this._name = wX("ASSIGN LINK PROMPT", portal.displayName);

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -50,28 +50,28 @@ const StateDialog = WDialog.extend({
     this._targetID = target.ID;
     this._html = L.DomUtil.create("div", null);
     const divtitle = L.DomUtil.create("div", "desc", this._html);
+    const menu = this._getStateMenu(target);
 
     if (target instanceof WasabeeLink) {
       const portal = operation.getPortal(target.fromPortalId);
       this._type = "Link";
-      divtitle.appendChild(
-        target.displayFormat(this._operation, this._smallScreen)
-      );
-      const t = L.DomUtil.create("span", null, divtitle);
-      t.textContent = wX("LINK STATE");
       this._name = wX("LINK STATE PROMPT", portal.name);
+      divtitle.appendChild(target.displayFormat(operation, this._smallScreen));
+      const t = L.DomUtil.create("label", null);
+      t.textContent = wX("LINK STATE");
+      menu.prepend(t);
     }
 
     if (target instanceof WasabeeMarker) {
       const portal = operation.getPortal(target.portalId);
       this._type = "Marker";
-      divtitle.appendChild(portal.displayFormat(this._smallScreen));
-      const t = L.DomUtil.create("span", null, divtitle);
-      t.textContent = wX("MARKER STATE");
       this._name = wX("MARKER STATE PROMPT", portal.name);
+      divtitle.appendChild(portal.displayFormat(this._smallScreen));
+      const t = L.DomUtil.create("label", null);
+      t.textContent = wX("MARKER STATE");
+      menu.prepend(t);
     }
 
-    const menu = this._getStateMenu(target);
     this._html.appendChild(menu);
   },
 


### PR DESCRIPTION
https://github.com/wasabee-project/Wasabee-IITC/blob/bbdd4f47a456ffe7fb6b11c2590874ca03006d35/src/code/link.js#L103-L104

Edit about second commit:
as far I understand, the description is used as a label in those dialogs but is placed right after the portal(s) name(s) in the same `<div>`. 
it sounds more logical to use it like in the settings dialog, using real `<label>` since the description and the `<select>` menu match.