### PR TITLE
changes on some dialogs + random fixes

### DIFF
--- a/src/code/buttons/quickdrawButton.js
+++ b/src/code/buttons/quickdrawButton.js
@@ -55,12 +55,15 @@ const QuickDrawControl = L.Handler.extend({
 
   enable: function () {
     console.log("qd enable called");
-    if (this._enabled) return;
+    if (this._enabled) {
+      this.disable();
+      return;
+    }
     L.Handler.prototype.enable.call(this);
     window.plugin.wasabee.buttons._modes[this.buttonName].enable();
-    window.plugin.wasabee.buttons._modes[
-      this.buttonName
-    ].button.style.backgroundColor = "#55bb55";
+    window.plugin.wasabee.buttons._modes[this.buttonName].button.classList.add(
+      "active"
+    );
     postToFirebase({ id: "analytics", action: "quickdrawStart" });
   },
 
@@ -71,7 +74,7 @@ const QuickDrawControl = L.Handler.extend({
     window.plugin.wasabee.buttons._modes[this.buttonName].disable();
     window.plugin.wasabee.buttons._modes[
       this.buttonName
-    ].button.style.backgroundColor = "#ffffff";
+    ].button.classList.remove("active");
     postToFirebase({ id: "analytics", action: "quickdrawEnd" });
   },
 

--- a/src/code/buttons/syncButton.js
+++ b/src/code/buttons/syncButton.js
@@ -34,34 +34,36 @@ const SyncButton = WButton.extend({
       context: this,
       callback: () => {
         const so = getSelectedOperation();
-        const me = WasabeeMe.get(true); // force update of ops list
-        // const me = await WasabeeMe.waitGet(true); // force update of ops list
-        if (!me) {
-          const ad = new AuthDialog();
-          ad.enable();
-          return;
-        }
-
-        const promises = new Array();
-        const opsID = new Set(me.Ops.map((o) => o.ID));
-        for (const opID of opsID) {
-          promises.push(opPromise(opID));
-        }
-        Promise.all(promises).then(
-          (ops) => {
-            for (const newop of ops) {
-              newop.store();
-              if (newop.ID == so.ID) {
-                makeSelectedOperation(newop.ID);
-              }
-            }
-            alert(wX("SYNC DONE"));
-          },
-          function (err) {
-            console.log(err);
-            alert(err);
+        // force update of ops list
+        // const me = WasabeeMe.get(true); // force update of ops list
+        WasabeeMe.waitGet(true).then((me) => {
+          if (!me) {
+            const ad = new AuthDialog();
+            ad.enable();
+            return;
           }
-        );
+
+          const promises = new Array();
+          const opsID = new Set(me.Ops.map((o) => o.ID));
+          for (const opID of opsID) {
+            promises.push(opPromise(opID));
+          }
+          Promise.all(promises).then(
+            (ops) => {
+              for (const newop of ops) {
+                newop.store();
+                if (newop.ID == so.ID) {
+                  makeSelectedOperation(newop.ID);
+                }
+              }
+              alert(wX("SYNC DONE"));
+            },
+            function (err) {
+              console.log(err);
+              alert(err);
+            }
+          );
+        });
       },
     });
 

--- a/src/code/buttons/syncButton.js
+++ b/src/code/buttons/syncButton.js
@@ -43,8 +43,9 @@ const SyncButton = WButton.extend({
         }
 
         const promises = new Array();
-        for (const op of me.Ops) {
-          promises.push(opPromise(op.ID));
+        const opsID = new Set(me.Ops.map((o) => o.ID));
+        for (const opID of opsID) {
+          promises.push(opPromise(opID));
         }
         Promise.all(promises).then(
           (ops) => {

--- a/src/code/buttons/wasabeeButton.js
+++ b/src/code/buttons/wasabeeButton.js
@@ -1,6 +1,6 @@
 import { WButton } from "../leafletClasses";
 import WasabeeMe from "../me";
-import WasabeeDialog from "../dialogs/wasabeeDialog";
+import TeamListDialog from "../dialogs/teamListDialog";
 import AuthDialog from "../dialogs/authDialog";
 import ConfirmDialog from "../dialogs/confirmDialog";
 import NewopDialog from "../dialogs/newopDialog";
@@ -53,7 +53,7 @@ const WasabeeButton = WButton.extend({
       text: wX("TEAMS BUTTON"),
       callback: () => {
         this.disable();
-        const wd = new WasabeeDialog(this._map);
+        const wd = new TeamListDialog(this._map);
         wd.enable();
       },
       context: this,
@@ -88,7 +88,7 @@ const WasabeeButton = WButton.extend({
       text: wX("TEAMS BUTTON"),
       callback: () => {
         this.disable();
-        const wd = new WasabeeDialog(this._map);
+        const wd = new TeamListDialog(this._map);
         wd.enable();
       },
       context: this,

--- a/src/code/css/wasabee.css
+++ b/src/code/css/wasabee.css
@@ -576,7 +576,7 @@
 }
 .wasabee-dialog-link div.container {
   display: grid;
-  grid-template-columns: (repeat 5, auto);
+  grid-template-columns: (repeat 4, auto);
   grid-tempate-rows: (repeat 4, auto);
 }
 
@@ -605,12 +605,12 @@
   grid-column: 4;
   margin: 5px;
 }
-.wasabee-dialog-link button.clear {
+/*.wasabee-dialog-link button.clear {
   grid-column: 5;
   text-decoration: underline;
   cursor: pointer;
   margin: 5px;
-}
+}*/
 
 .wasabee-dialog-link buttonall {
   cursor: pointer;

--- a/src/code/css/wasabee.css
+++ b/src/code/css/wasabee.css
@@ -19,6 +19,11 @@
   top: 0;
   white-space: nowrap;
 }
+
+.wasabee-buttons.leaflet-control a.active {
+  background-color: #3c9;
+}
+
 .wasabee-actions li {
   display: inline-block;
 }

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -65,15 +65,15 @@ const LinkDialog = WDialog.extend({
         alert(wX("PLEASE_SELECT_PORTAL"));
       }
     });
-    const clearSourceButton = L.DomUtil.create("button", "clear", container);
-    clearSourceButton.textContent = wX("CLEAR");
-    L.DomEvent.on(clearSourceButton, "click", (ev) => {
-      L.DomEvent.stop(ev);
-      delete localStorage[
-        window.plugin.wasabee.static.constants.LINK_SOURCE_KEY
-      ];
-      this._sourceDisplay.textContent = wX("NOT_SET");
-    });
+    // const clearSourceButton = L.DomUtil.create("button", "clear", container);
+    // clearSourceButton.textContent = wX("CLEAR");
+    // L.DomEvent.on(clearSourceButton, "click", (ev) => {
+    //   L.DomEvent.stop(ev);
+    //   delete localStorage[
+    //     window.plugin.wasabee.static.constants.LINK_SOURCE_KEY
+    //   ];
+    //   this._sourceDisplay.textContent = wX("NOT_SET");
+    // });
 
     const anchor1Label = L.DomUtil.create("label", null, container);
     anchor1Label.textContent = wX("ANCHOR1");
@@ -117,15 +117,15 @@ const LinkDialog = WDialog.extend({
         alert("Select both Source and Anchor 1");
       }
     });
-    const clearAnchor1Button = L.DomUtil.create("button", "clear", container);
-    clearAnchor1Button.textContent = wX("CLEAR");
-    L.DomEvent.on(clearAnchor1Button, "click", (ev) => {
-      L.DomEvent.stop(ev);
-      delete localStorage[
-        window.plugin.wasabee.static.constants.ANCHOR_ONE_KEY
-      ];
-      this._anchor1Display.textContent = wX("NOT_SET");
-    });
+    // const clearAnchor1Button = L.DomUtil.create("button", "clear", container);
+    // clearAnchor1Button.textContent = wX("CLEAR");
+    // L.DomEvent.on(clearAnchor1Button, "click", (ev) => {
+    //   L.DomEvent.stop(ev);
+    //   delete localStorage[
+    //     window.plugin.wasabee.static.constants.ANCHOR_ONE_KEY
+    //   ];
+    //   this._anchor1Display.textContent = wX("NOT_SET");
+    // });
 
     const anchor2Label = L.DomUtil.create("label", null, container);
     anchor2Label.textContent = wX("ANCHOR2");
@@ -169,15 +169,15 @@ const LinkDialog = WDialog.extend({
         alert(wX("SEL_SRC_ANC2"));
       }
     });
-    const clearAnchor2Button = L.DomUtil.create("button", "clear", container);
-    clearAnchor2Button.textContent = wX("CLEAR");
-    L.DomEvent.on(clearAnchor2Button, "click", (ev) => {
-      L.DomEvent.stop(ev);
-      delete localStorage[
-        window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY
-      ];
-      this._anchor2Display.textContent = wX("NOT_SET");
-    });
+    // const clearAnchor2Button = L.DomUtil.create("button", "clear", container);
+    // clearAnchor2Button.textContent = wX("CLEAR");
+    // L.DomEvent.on(clearAnchor2Button, "click", (ev) => {
+    //   L.DomEvent.stop(ev);
+    //   delete localStorage[
+    //     window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY
+    //   ];
+    //   this._anchor2Display.textContent = wX("NOT_SET");
+    // });
 
     // Bottom buttons bar
     // Enter arrow

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -236,6 +236,7 @@ const ManageTeamDialog = WDialog.extend({
           deleteTeamPromise(this._team.ID).then(
             () => {
               alert(`${this._team.Name} removed`);
+              this._dialog.dialog("close");
               window.runHooks("wasabeeUIUpdate", getSelectedOperation());
             },
             (reject) => {

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -9,6 +9,7 @@ import {
   deleteTeamPromise,
   GetWasabeeServer,
 } from "../server";
+import WasabeeMe from "../me";
 import Sortable from "../../lib/sortable";
 import { getSelectedOperation } from "../selectedOp";
 import PromptDialog from "./promptDialog";
@@ -237,7 +238,8 @@ const ManageTeamDialog = WDialog.extend({
             () => {
               alert(`${this._team.Name} removed`);
               this._dialog.dialog("close");
-              window.runHooks("wasabeeUIUpdate", getSelectedOperation());
+              WasabeeMe.get(true);
+              //window.runHooks("wasabeeUIUpdate", getSelectedOperation());
             },
             (reject) => {
               console.log(reject);

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -166,7 +166,6 @@ const OpsDialog = WDialog.extend({
       L.DomEvent.on(clearOpButton, "click", (ev) => {
         L.DomEvent.stop(ev);
         clearAllItems(selectedOp);
-        selectedOp.store();
       });
     }
 

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -11,15 +11,15 @@ import ManageTeamDialog from "./manageTeamDialog";
 import wX from "../wX";
 import { postToFirebase } from "../firebaseSupport";
 
-const WasabeeDialog = WDialog.extend({
+const TeamListDialog = WDialog.extend({
   statics: {
     TYPE: "wasabeeButton",
   },
 
   initialize: function (map = window.map, options) {
-    this.type = WasabeeDialog.TYPE;
+    this.type = TeamListDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: WasabeeDialog.TYPE });
+    postToFirebase({ id: "analytics", action: TeamListDialog.TYPE });
   },
 
   addHooks: async function () {
@@ -203,4 +203,4 @@ const WasabeeDialog = WDialog.extend({
   },
 });
 
-export default WasabeeDialog;
+export default TeamListDialog;

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -38,6 +38,7 @@ const TeamListDialog = WDialog.extend({
   update: function () {
     // async
     if (!this._enabled) return;
+    this._me = WasabeeMe.get();
     // this._me = await WasabeeMe.waitGet(); // breaks logout
     this._dialog.html(this._buildContent());
   },
@@ -97,7 +98,7 @@ const TeamListDialog = WDialog.extend({
                 leaveTeamPromise(obj.ID).then(
                   async () => {
                     this._me = await WasabeeMe.waitGet(true);
-                    window.runHooks("wasabeeUIUpdate", getSelectedOperation());
+                    //window.runHooks("wasabeeUIUpdate", getSelectedOperation());
                   },
                   (err) => {
                     console.log(err);
@@ -162,7 +163,7 @@ const TeamListDialog = WDialog.extend({
         newTeamPromise(newname).then(
           () => {
             alert(wX("TEAM_CREATED", newname));
-            window.runHooks("wasabeeUIUpdate", getSelectedOperation());
+            this._me = WasabeeMe.get(true);
           },
           (reject) => {
             console.log(reject);

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -5,7 +5,6 @@ import { SetTeamState, leaveTeamPromise, newTeamPromise } from "../server";
 import PromptDialog from "./promptDialog";
 import AuthDialog from "./authDialog";
 import TeamMembershipList from "./teamMembershipList";
-import { getSelectedOperation } from "../selectedOp";
 import ConfirmDialog from "./confirmDialog";
 import ManageTeamDialog from "./manageTeamDialog";
 import wX from "../wX";
@@ -74,10 +73,10 @@ const TeamListDialog = WDialog.extend({
           let curstate = obj.State;
           link.textContent = curstate;
           if (curstate == "On") L.DomUtil.addClass(link, "enl");
-          link.onclick = async () => {
-            await this.toggleTeam(obj.ID, curstate);
-            this._me = await WasabeeMe.waitGet(true);
-            window.runHooks("wasabeeUIUpdate", getSelectedOperation());
+          link.onclick = () => {
+            this.toggleTeam(obj.ID, curstate);
+            // WasabeeMe.get(true); // called by toggleTeam
+            // window.runHooks("wasabeeUIUpdate", getSelectedOperation()); // called by WasabeeMe.get(true)
           };
         },
       },
@@ -96,9 +95,9 @@ const TeamListDialog = WDialog.extend({
               `If you leave ${obj.Name} you cannot rejoin unless the owner re-adds you.`,
               () => {
                 leaveTeamPromise(obj.ID).then(
-                  async () => {
-                    this._me = await WasabeeMe.waitGet(true);
-                    //window.runHooks("wasabeeUIUpdate", getSelectedOperation());
+                  () => {
+                    WasabeeMe.get(true);
+                    // window.runHooks("wasabeeUIUpdate", getSelectedOperation()); // called by WasabeeMe.get(true)
                   },
                   (err) => {
                     console.log(err);
@@ -163,7 +162,7 @@ const TeamListDialog = WDialog.extend({
         newTeamPromise(newname).then(
           () => {
             alert(wX("TEAM_CREATED", newname));
-            this._me = WasabeeMe.get(true);
+            WasabeeMe.get(true); // triggers UIUpdate
           },
           (reject) => {
             console.log(reject);
@@ -195,7 +194,7 @@ const TeamListDialog = WDialog.extend({
     if (currentState == "Off") newState = "On";
 
     await SetTeamState(teamID, newState);
-    this._me = await WasabeeMe.waitGet(true);
+    await WasabeeMe.get(true);
     return newState;
   },
 

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -128,7 +128,7 @@ window.plugin.wasabee.init = function () {
   // has not yet expired, we would think we were logged in when really not
   // this forces an update on reload
   if (WasabeeMe.isLoggedIn()) {
-    // this updates the UI if needed
+    // this updates the UI
     WasabeeMe.get(true);
   }
 

--- a/src/code/uiCommands.js
+++ b/src/code/uiCommands.js
@@ -324,4 +324,6 @@ export const blockerAutomark = function (operation, first = true) {
   });
   // recurse
   blockerAutomark(operation, false);
+
+  if (first) operation.endBatchMode();
 };

--- a/src/code/wX.js
+++ b/src/code/wX.js
@@ -30,9 +30,9 @@ export const wX = (key, value, option) => {
 
   // do any necessary replacements
   // eslint-disable-next-line
-  if (option) s = s.replace("${option}", option);
+  if (option !== undefined) s = s.replace("${option}", option);
   // eslint-disable-next-line
-  if (value) s = s.replace("${value}", value);
+  if (value !== undefined) s = s.replace("${value}", value);
   return s;
 };
 


### PR DESCRIPTION
 * rename wasabeeDialog
 * prevent error on team deletion
 * remove "clean selection" on linkDialog (because it is redundant and reduces the usability of the dialog)
 * reduce UIUpdate hook calls
 * pull one draw per OP (instead of per OP/team)
 * use async for sync...
 * fix automark leaving OP in batchmode
 * add toggle button for quickdraw (even if subactions disappear)