### PR TITLE
Change markertype

### DIFF
--- a/src/code/css/wasabee.css
+++ b/src/code/css/wasabee.css
@@ -253,6 +253,14 @@
   font-weight: initial;
 }
 
+.wasabee-marker-popup-kind {
+  cursor: pointer;
+}
+
+.wasabee-marker-popup-kind:hover {
+  text-decoration: underline;
+}
+
 .wasabee-marker-buttonset {
 }
 .wasabee-marker-buttonset button {

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -1,0 +1,84 @@
+import { WDialog } from "../leafletClasses";
+import wX from "../wX";
+import { postToFirebase } from "../firebaseSupport";
+
+const MarkerChangeDialog = WDialog.extend({
+  statics: {
+    TYPE: "markerButton",
+  },
+
+  initialize: function (map = window.map, options) {
+    this.type = MarkerChangeDialog.TYPE;
+    WDialog.prototype.initialize.call(this, map, options);
+    postToFirebase({ id: "analytics", action: MarkerChangeDialog.TYPE });
+  },
+
+  addHooks: function () {
+    if (!this._map) return;
+    WDialog.prototype.addHooks.call(this);
+    this._displayDialog();
+  },
+
+  removeHooks: function () {
+    WDialog.prototype.removeHooks.call(this);
+  },
+
+  setup: function (target, operation) {
+    this._marker = target;
+    this._operation = operation;
+  },
+
+  _displayDialog: function () {
+    const content = L.DomUtil.create("div", "content");
+
+    const portal = this._operation.getPortal(this._marker.portalId);
+    const portalDisplay = L.DomUtil.create("div", "portal", content);
+
+    portalDisplay.appendChild(portal.displayFormat(this._smallScreen));
+
+    this._type = L.DomUtil.create("select", null, content);
+
+    const markers = this._operation.getPortalMarkers(portal);
+    for (const k of window.plugin.wasabee.skin.markerTypes.keys()) {
+      const o = L.DomUtil.create("option", null, this._type);
+      o.value = k;
+      o.textContent = wX(k);
+      if (markers.has(k) && k != this._marker.type) o.disabled = true;
+    }
+    this._type.value = this._marker.type;
+
+    const buttons = {};
+    buttons[wX("OK")] = () => {
+      if (
+        window.plugin.wasabee.static.markerTypes.has(this._type.value) &&
+        !markers.has(this._type.value)
+      ) {
+        this._operation.removeMarker(this._marker);
+        this._operation.addMarker(
+          this._type.value,
+          portal,
+          this._marker.comment
+        );
+      }
+      this._dialog.dialog("close");
+    };
+    buttons[wX("CANCEL")] = () => {
+      this._dialog.dialog("close");
+    };
+
+    this._dialog = window.dialog({
+      title: wX("SET_MARKER_TYPE_TITLE"),
+      html: content,
+      width: "auto",
+      dialogClass: "wasabee-dialog wasabee-dialog-markerchange",
+      buttons: buttons,
+      closeCallback: () => {
+        this.disable();
+        delete this._dialog;
+      },
+      id: window.plugin.wasabee.static.dialogNames.markerButton,
+    });
+  },
+});
+
+export default MarkerChangeDialog;

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -2,6 +2,7 @@ import { WDialog } from "../leafletClasses";
 import Sortable from "../../lib/sortable";
 import AssignDialog from "./assignDialog";
 import SetCommentDialog from "./setCommentDialog";
+import MarkerChangeDialog from "./markerChangeDialog";
 import { agentPromise } from "../server";
 import { getSelectedOperation } from "../selectedOp";
 // import WasabeeMe from "../me";
@@ -101,6 +102,12 @@ const MarkerList = WDialog.extend({
         format: (cell, value, marker) => {
           const d = L.DomUtil.create("span", marker.type, cell);
           d.textContent = value;
+          L.DomEvent.on(cell, "click", (ev) => {
+            L.DomEvent.stop(ev);
+            const ch = new MarkerChangeDialog();
+            ch.setup(marker, operation);
+            ch.enable();
+          });
         },
       },
       {

--- a/src/code/dialogs/operationChecklistDialog.js
+++ b/src/code/dialogs/operationChecklistDialog.js
@@ -1,9 +1,11 @@
 import { WDialog } from "../leafletClasses";
 import WasabeeLink from "../link";
+import WasabeeMarker from "../marker";
 import Sortable from "../../lib/sortable";
 import AssignDialog from "./assignDialog";
 import StateDialog from "./stateDialog";
 import SetCommentDialog from "./setCommentDialog";
+import MarkerChangeDialog from "./markerChangeDialog";
 import { agentPromise } from "../server";
 import {
   listenForAddedPortals,
@@ -143,6 +145,15 @@ const OperationChecklistDialog = WDialog.extend({
           const span = L.DomUtil.create("span", null, cell);
           if (thing.type) L.DomUtil.addClass(span, thing.type);
           span.textContent = value;
+
+          if (thing instanceof WasabeeMarker) {
+            L.DomEvent.on(cell, "click", (ev) => {
+              L.DomEvent.stop(ev);
+              const ch = new MarkerChangeDialog();
+              ch.setup(thing, operation);
+              ch.enable();
+            });
+          }
         },
       },
       {

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -4,6 +4,7 @@ import { agentPromise } from "./server";
 import AssignDialog from "./dialogs/assignDialog";
 import wX from "./wX";
 import SetCommentDialog from "./dialogs/setCommentDialog";
+import MarkerChangeDialog from "./dialogs/markerChangeDialog";
 
 export default class WasabeeMarker {
   constructor(type, portalId, comment) {
@@ -132,6 +133,15 @@ export default class WasabeeMarker {
     L.DomUtil.addClass(kind, this.type);
     kind.textContent = wX(this.type);
     title.appendChild(portal.displayFormat());
+
+    kind.href = "#";
+    L.DomEvent.on(kind, "click", (ev) => {
+      L.DomEvent.stop(ev);
+      const ch = new MarkerChangeDialog();
+      ch.setup(this, operation);
+      ch.enable();
+      marker.closePopup();
+    });
 
     if (this.comment) {
       const comment = L.DomUtil.create(

--- a/src/code/translations/english.json
+++ b/src/code/translations/english.json
@@ -285,6 +285,7 @@
   "SET_LINK_COMMENT": "Set comment for link: ",
   "SET_LCOMMENT": "Set Link Comment",
   "SET_MARKER_COMMENT": "Set comment for marker on: ",
+  "SET_MARKER_TYPE_TITLE": "Change marker type",
   "SET_MCOMMENT": "Set Marker Comment: ${value}",
   "SET_NEW_OP": "Please Set the New Operation Name",
   "SET_PORT_COMMENT": "Set comment for portal: ",


### PR DESCRIPTION
add dialog to change marker type from popup, marker list and checklist

note: I use the css change to avoid a `<a>` tag which style is define elsewhere (like the comment in the popup)