### PR TITLE
Rebase on update

### DIFF
--- a/src/code/buttons/uploadButton.js
+++ b/src/code/buttons/uploadButton.js
@@ -110,9 +110,19 @@ const UploadButton = WButton.extend({
   },
 
   doUpdate: async function (op) {
+    const operation = getSelectedOperation();
+    if (op) {
+      const changes = operation.changes();
+      console.log(changes);
+      op.applyChanges(changes, operation);
+      op.cleanAll();
+      // reload selected OP
+      op = makeSelectedOperation(op.ID);
+    } else op = operation;
     await updateOpPromise(op);
     op.localchanged = false;
     op.fetched = new Date().toUTCString();
+    op.fetchedOp = op.toJSON();
     op.store();
     alert(wX("UPDATED"));
     this.Wupdate(this._container, op);
@@ -129,12 +139,12 @@ const UploadButton = WButton.extend({
           md.setup(
             wX("UPDATE_CONFLICT_TITLE"),
             wX("UPDATE_CONFLICT_DESC"),
-            () => this.doUpdate(operation)
+            () => this.doUpdate(lastOp)
           );
           md.enable();
         } else {
           // no conflict
-          this.doUpdate(operation);
+          this.doUpdate();
         }
       } catch (e) {
         console.error(e);

--- a/src/code/buttons/uploadButton.js
+++ b/src/code/buttons/uploadButton.js
@@ -122,7 +122,7 @@ const UploadButton = WButton.extend({
     await updateOpPromise(op);
     op.localchanged = false;
     op.fetched = new Date().toUTCString();
-    op.fetchedOp = op.toJSON();
+    op.fetchedOp = JSON.stringify(op);
     op.store();
     alert(wX("UPDATED"));
     this.Wupdate(this._container, op);

--- a/src/code/buttons/uploadButton.js
+++ b/src/code/buttons/uploadButton.js
@@ -111,7 +111,10 @@ const UploadButton = WButton.extend({
 
   doUpdate: async function (op) {
     const operation = getSelectedOperation();
-    if (op) {
+    const rebaseOnUpdate =
+      localStorage[window.plugin.wasabee.static.constants.REBASE_UPDATE_KEY] ===
+      "true";
+    if (rebaseOnUpdate && op) {
       const changes = operation.changes();
       console.log(changes);
       op.applyChanges(changes, operation);

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -153,6 +153,21 @@ const SettingsDialog = WDialog.extend({
       localStorage[urpKey] = urpSelect.value;
     });
 
+    const rebaseUpdateTitle = L.DomUtil.create("label", null, container);
+    rebaseUpdateTitle.textContent =
+      "Rebase on update (alpha, may break your op)";
+    rebaseUpdateTitle.htmlFor = "wasabee-setting-rebase-update";
+    const rebaseUpdateCheck = L.DomUtil.create("input", null, container);
+    rebaseUpdateCheck.type = "checkbox";
+    rebaseUpdateCheck.id = "wasabee-setting-rebase-update";
+    const ruc = window.plugin.wasabee.static.constants.REBASE_UPDATE_KEY;
+    const ru = localStorage[ruc];
+    if (ru === "true") rebaseUpdateCheck.checked = true;
+    L.DomEvent.on(rebaseUpdateCheck, "change", (ev) => {
+      L.DomEvent.stop(ev);
+      localStorage[ruc] = rebaseUpdateCheck.checked;
+    });
+
     const autoLoadTitle = L.DomUtil.create("label", null, container);
     autoLoadTitle.textContent = wX("AUTOLOAD");
     autoLoadTitle.htmlFor = "wasabee-setting-autoload";

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -1168,15 +1168,13 @@ export default class WasabeeOp {
       else if (d.type == "marker")
         this.markers = this.markers.filter((m) => m.ID != d.id);
     }
+    // `this` takes over `changes` for additions
     for (const a of changes.addition) {
-      // `this` takes over `changes`
       if (a.type == "portal") this._addPortal(a.portal);
       else if (a.type == "link") {
-        // `this` takes over `changes`
         if (!this.getLinkByPortalIDs(a.link.fromPortalId, a.link.toPortalId))
           this.links.push(a.link);
       } else if (a.type == "marker") {
-        // `this` takes over `changes`
         if (!this.containsMarkerByID(a.marker.portalId, a.marker.type))
           this.markers.push(a.marker);
       }

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -41,6 +41,8 @@ export default class WasabeeOp {
 
     this.server = this.fetched ? obj.server : null;
 
+    this.fetchedOp = obj.fetchedOp ? obj.fetchedOp : null;
+
     if (!this.links) this.links = new Array();
     if (!this.markers) this.markers = new Array();
     if (!this.blockers) this.blockers = new Array();
@@ -70,7 +72,11 @@ export default class WasabeeOp {
 
   store() {
     this.stored = Date.now();
-    localStorage[this.ID] = JSON.stringify(this);
+    const json = this.toJSON();
+    // ignored by the server but useful for localStorage
+    json.server = this.server;
+    json.fetchedOp = this.fetchedOp;
+    localStorage[this.ID] = JSON.stringify(json);
     addOperation(this.ID);
 
     // some debug info to trace race condition
@@ -99,8 +105,6 @@ export default class WasabeeOp {
       keysonhand: this.keysonhand,
       mode: this.mode,
       zones: this.zones,
-      // ignored by the server but useful for localStorage
-      server: this.server,
     };
   }
 

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -1128,6 +1128,7 @@ export default class WasabeeOp {
           "description",
           "throwOrderPos",
           "color",
+          "completed",
           "zone",
         ];
         const diff = fields
@@ -1148,7 +1149,14 @@ export default class WasabeeOp {
         changes.addition.push({ type: "marker", marker: m });
       } else {
         const oldMarker = oldMarkers.get(m.ID);
-        const fields = ["type", "comment", "assignedTo", "order", "zone"];
+        const fields = [
+          "type",
+          "comment",
+          "assignedTo",
+          "state",
+          "order",
+          "zone",
+        ];
         const diff = fields
           .filter((k) => oldMarker[k] != m[k])
           .map((k) => [k, m[k]]);
@@ -1179,6 +1187,7 @@ export default class WasabeeOp {
           this.markers.push(a.marker);
       }
     }
+    // links/markers absent from `this` are not added back
     for (const e of changes.edition) {
       if (e.type == "portal") {
         const portal = this.getPortal(e.type.portal.id);

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -1089,9 +1089,8 @@ export default class WasabeeOp {
       edition: new Array(),
       deletion: new Array(),
     };
-    // old OP or local OP
-    if (!this.fetchedOp) return changes;
-    const oldOp = new WasabeeOp(this.fetchedOp);
+    // empty op if old OP (or local OP)
+    const oldOp = new WasabeeOp(this.fetchedOp || {});
     const oldLinks = new Map(oldOp.links.map((l) => [l.ID, l]));
     const oldMarkers = new Map(oldOp.markers.map((m) => [m.ID, m]));
 
@@ -1103,7 +1102,7 @@ export default class WasabeeOp {
         changes.addition.push({ type: "portal", portal: p });
       else {
         const oldPortal = oldOp._idToOpportals.get(id);
-        const fields = ["name", "lat", "lng", "comment", "hardness"];
+        const fields = ["comment", "hardness"];
         const diff = fields
           .filter((k) => oldPortal[k] != p[k])
           .map((k) => [k, p[k]]);
@@ -1183,7 +1182,10 @@ export default class WasabeeOp {
       }
     }
     for (const e of changes.edition) {
-      if (e.type == "link") {
+      if (e.type == "portal") {
+        const portal = this.getPortal(e.type.portal.id);
+        for (const [k, v] of e.diff) portal[k] = v;
+      } else if (e.type == "link") {
         for (const l of this.links) {
           if (l.ID == e.link.ID) {
             const link = this.getLinkByPortalIDs(

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -238,16 +238,20 @@ export default class WasabeeOp {
     return markers;
   }
 
-  getLink(portal1, portal2) {
+  getLinkByPortalIDs(portalId1, portalId2) {
     for (const l of this.links) {
       if (
-        (l.fromPortalId == portal1.id && l.toPortalId == portal2.id) ||
-        (l.fromPortalId == portal2.id && l.toPortalId == portal1.id)
+        (l.fromPortalId == portalId1 && l.toPortalId == portalId2) ||
+        (l.fromPortalId == portalId2 && l.toPortalId == portalId1)
       ) {
         return l;
       }
     }
     return null;
+  }
+
+  getLink(portal1, portal2) {
+    return this.getLinkByPortalIDs(portal1.id, portal2.id);
   }
 
   getLinkListFromPortal(portal) {

--- a/src/code/server.js
+++ b/src/code/server.js
@@ -80,6 +80,7 @@ export async function opPromise(opID) {
         newop = new WasabeeOp(raw);
         newop.localchanged = false;
         newop.server = server;
+        newop.fetchedOp = raw;
         return Promise.resolve(newop);
       case 304: // If-Modified-Since replied NotModified
         console.warn("server copy is older/unmodified, keeping local copy");

--- a/src/code/server.js
+++ b/src/code/server.js
@@ -80,7 +80,7 @@ export async function opPromise(opID) {
         newop = new WasabeeOp(raw);
         newop.localchanged = false;
         newop.server = server;
-        newop.fetchedOp = raw;
+        newop.fetchedOp = JSON.stringify(raw);
         return Promise.resolve(newop);
       case 304: // If-Modified-Since replied NotModified
         console.warn("server copy is older/unmodified, keeping local copy");

--- a/src/code/static.js
+++ b/src/code/static.js
@@ -60,6 +60,7 @@ W.static = {
       "269534461245-jbnes60ebd7u0b8naba19h4vqm7ji219.apps.googleusercontent.com",
     SERVER_BASE_KEY: "wasabee-server",
     SERVER_BASE_DEFAULT: "https://am.wasabee.rocks",
+    REBASE_UPDATE_KEY: "wasabee-rebase-on-update",
     MARKER_TYPE_CAPTURE: "CapturePortalMarker",
     MARKER_TYPE_DECAY: "LetDecayPortalAlert",
     MARKER_TYPE_EXCLUDE: "ExcludeMarker",


### PR DESCRIPTION
- save last fetch json inside the OP object
- generate a diff before updating
- if server changed, apply diff on the server version, store and update

Apply diff:
 - if no ID matches (multiple editor on OP from 0.18 or at least on editor using 018), rewrite diff to match server IDs whenever it's possible (same link portals, same marker portal+type)
 - merge the zones (ignoring local names)
 - use IDs to apply deletion/editions, edition on absent IDs are lost (another user removed the entities)
 