### PR TITLE
Simplify WDialog logic

### DIFF
--- a/src/code/agent.js
+++ b/src/code/agent.js
@@ -169,19 +169,18 @@ export default class WasabeeAgent {
         return;
       }
 
-      const d = new ConfirmDialog();
-      d.setup(
-        wX("SEND TARGET"),
-        wX("SEND TARGET CONFIRM", selectedPortal.displayName, this.name),
-        async () => {
+      const d = new ConfirmDialog(window.map, {
+        title: wX("SEND TARGET"),
+        label: wX("SEND TARGET CONFIRM", selectedPortal.displayName, this.name),
+        callback: async () => {
           try {
             await targetPromise(this.id, selectedPortal);
             alert(wX("TARGET SENT"));
           } catch (e) {
             console.error(e);
           }
-        }
-      );
+        },
+      });
       d.enable();
     });
 
@@ -197,19 +196,18 @@ export default class WasabeeAgent {
         return;
       }
 
-      const d = new ConfirmDialog();
-      d.setup(
-        "Send Route to Target",
-        "Do you really want to request the route to be sent?",
-        async () => {
+      const d = new ConfirmDialog(window.map, {
+        title: "Send Route to Target",
+        label: "Do you really want to request the route to be sent?",
+        callback: async () => {
           try {
             await routePromise(this.id, selectedPortal);
             alert("Route Sent");
           } catch (e) {
             console.error(e);
           }
-        }
-      );
+        },
+      });
       d.enable();
     });
 

--- a/src/code/agent.js
+++ b/src/code/agent.js
@@ -135,7 +135,7 @@ export default class WasabeeAgent {
     }
     L.DomEvent.on(display, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const ad = new AgentDialog(window.map, { gid: this.id });
+      const ad = new AgentDialog({ gid: this.id });
       ad.enable();
     });
     if (teamID == "all") {
@@ -169,7 +169,7 @@ export default class WasabeeAgent {
         return;
       }
 
-      const d = new ConfirmDialog(window.map, {
+      const d = new ConfirmDialog({
         title: wX("SEND TARGET"),
         label: wX("SEND TARGET CONFIRM", selectedPortal.displayName, this.name),
         callback: async () => {
@@ -196,7 +196,7 @@ export default class WasabeeAgent {
         return;
       }
 
-      const d = new ConfirmDialog(window.map, {
+      const d = new ConfirmDialog({
         title: "Send Route to Target",
         label: "Do you really want to request the route to be sent?",
         callback: async () => {

--- a/src/code/anchor.js
+++ b/src/code/anchor.js
@@ -175,8 +175,7 @@ export default class WasabeeAnchor {
       sendButton.textContent = wX("SEND TARGET");
       L.DomEvent.on(sendButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const std = new SendTargetDialog();
-        std.setup(this, operation);
+        const std = new SendTargetDialog(window.map, { target: this });
         std.enable();
         marker.closePopup();
       });

--- a/src/code/anchor.js
+++ b/src/code/anchor.js
@@ -82,7 +82,7 @@ export default class WasabeeAnchor {
     pcLink.href = "#";
     L.DomEvent.on(pcLink, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const scd = new SetCommentDialog(window.map, {
+      const scd = new SetCommentDialog({
         target: this._portal,
         operation: operation,
       });
@@ -100,7 +100,7 @@ export default class WasabeeAnchor {
       phLink.href = "#";
       L.DomEvent.on(phLink, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const scd = new SetCommentDialog(window.map, {
+        const scd = new SetCommentDialog({
           target: this._portal,
           operation: operation,
         });
@@ -117,7 +117,7 @@ export default class WasabeeAnchor {
     linksButton.textContent = wX("LINKS");
     L.DomEvent.on(linksButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const lld = new LinkListDialog(window.map, { portal: this._portal });
+      const lld = new LinkListDialog({ portal: this._portal });
       lld.enable();
       marker.closePopup();
     });
@@ -169,7 +169,7 @@ export default class WasabeeAnchor {
       assignButton.textContent = wX("ASSIGN OUTBOUND");
       L.DomEvent.on(assignButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const ad = new AssignDialog(window.map, { target: this });
+        const ad = new AssignDialog({ target: this });
         ad.enable();
         marker.closePopup();
       });
@@ -179,7 +179,7 @@ export default class WasabeeAnchor {
       sendButton.textContent = wX("SEND TARGET");
       L.DomEvent.on(sendButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const std = new SendTargetDialog(window.map, { target: this });
+        const std = new SendTargetDialog({ target: this });
         std.enable();
         marker.closePopup();
       });

--- a/src/code/anchor.js
+++ b/src/code/anchor.js
@@ -82,9 +82,11 @@ export default class WasabeeAnchor {
     pcLink.href = "#";
     L.DomEvent.on(pcLink, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const cd = new SetCommentDialog();
-      cd.setup(this._portal, operation);
-      cd.enable();
+      const scd = new SetCommentDialog(window.map, {
+        target: this._portal,
+        operation: operation,
+      });
+      scd.enable();
       marker.closePopup();
     });
     if (this._portal.hardness) {
@@ -98,9 +100,11 @@ export default class WasabeeAnchor {
       phLink.href = "#";
       L.DomEvent.on(phLink, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const cd = new SetCommentDialog();
-        cd.setup(this._portal, operation);
-        cd.enable();
+        const scd = new SetCommentDialog(window.map, {
+          target: this._portal,
+          operation: operation,
+        });
+        scd.enable();
         marker.closePopup();
       });
     }

--- a/src/code/anchor.js
+++ b/src/code/anchor.js
@@ -166,8 +166,7 @@ export default class WasabeeAnchor {
       assignButton.textContent = wX("ASSIGN OUTBOUND");
       L.DomEvent.on(assignButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const ad = new AssignDialog();
-        ad.setup(this, operation);
+        const ad = new AssignDialog(window.map, { target: this });
         ad.enable();
         marker.closePopup();
       });

--- a/src/code/anchor.js
+++ b/src/code/anchor.js
@@ -113,8 +113,7 @@ export default class WasabeeAnchor {
     linksButton.textContent = wX("LINKS");
     L.DomEvent.on(linksButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const lld = new LinkListDialog();
-      lld.setup(operation, this._portal);
+      const lld = new LinkListDialog(window.map, { portal: this._portal });
       lld.enable();
       marker.closePopup();
     });

--- a/src/code/buttons/uploadButton.js
+++ b/src/code/buttons/uploadButton.js
@@ -153,7 +153,7 @@ const UploadButton = WButton.extend({
         } else {
           // need rebase or force
           if (!rebaseOnUpdate) {
-            const md = new ConfirmDialog(window.map, {
+            const md = new ConfirmDialog({
               title: wX("UPDATE_CONFLICT_TITLE"),
               label: wX("UPDATE_CONFLICT_DESC"),
               callback: () => this.doUpdate(getSelectedOperation(), true),
@@ -166,7 +166,7 @@ const UploadButton = WButton.extend({
             message.innerHTML =
               "Server OP has changed since last sync. Wasabee rebased your changes on top of the server OP. Check the summary (not visible on the map) and confirm in order to push.<br/>" +
               rebaseMessage.replaceAll(/\n/g, "<br/>");
-            const md = new ConfirmDialog(window.map, {
+            const md = new ConfirmDialog({
               title: wX("UPDATE_CONFLICT_TITLE"),
               label: message,
               callback: () => this.doUpdate(lastOp),

--- a/src/code/buttons/uploadButton.js
+++ b/src/code/buttons/uploadButton.js
@@ -153,12 +153,11 @@ const UploadButton = WButton.extend({
         } else {
           // need rebase or force
           if (!rebaseOnUpdate) {
-            const md = new ConfirmDialog();
-            md.setup(
-              wX("UPDATE_CONFLICT_TITLE"),
-              wX("UPDATE_CONFLICT_DESC"),
-              () => this.doUpdate(getSelectedOperation(), true)
-            );
+            const md = new ConfirmDialog(window.map, {
+              title: wX("UPDATE_CONFLICT_TITLE"),
+              label: wX("UPDATE_CONFLICT_DESC"),
+              callback: () => this.doUpdate(getSelectedOperation(), true),
+            });
             md.enable();
           } else {
             const lastOp = await opPromise(operation.ID);
@@ -167,10 +166,11 @@ const UploadButton = WButton.extend({
             message.innerHTML =
               "Server OP has changed since last sync. Wasabee rebased your changes on top of the server OP. Check the summary (not visible on the map) and confirm in order to push.<br/>" +
               rebaseMessage.replaceAll(/\n/g, "<br/>");
-            const md = new ConfirmDialog();
-            md.setup(wX("UPDATE_CONFLICT_TITLE"), message, () =>
-              this.doUpdate(lastOp)
-            );
+            const md = new ConfirmDialog(window.map, {
+              title: wX("UPDATE_CONFLICT_TITLE"),
+              label: message,
+              callback: () => this.doUpdate(lastOp),
+            });
             md.enable();
           }
         }

--- a/src/code/buttons/wasabeeButton.js
+++ b/src/code/buttons/wasabeeButton.js
@@ -41,7 +41,7 @@ const WasabeeButton = WButton.extend({
       text: wX("LOG IN"),
       callback: () => {
         this.disable();
-        const ad = new AuthDialog(this._map);
+        const ad = new AuthDialog();
         ad.enable();
       },
       context: this,
@@ -52,7 +52,7 @@ const WasabeeButton = WButton.extend({
       text: wX("TEAMS BUTTON"),
       callback: () => {
         this.disable();
-        const wd = new TeamListDialog(this._map);
+        const wd = new TeamListDialog();
         wd.enable();
       },
       context: this,
@@ -84,7 +84,7 @@ const WasabeeButton = WButton.extend({
       text: wX("TEAMS BUTTON"),
       callback: () => {
         this.disable();
-        const wd = new TeamListDialog(this._map);
+        const wd = new TeamListDialog();
         wd.enable();
       },
       context: this,
@@ -96,7 +96,7 @@ const WasabeeButton = WButton.extend({
         text: wX("OPS BUTTON"),
         callback: () => {
           this.disable();
-          const od = new OpsDialog(map);
+          const od = new OpsDialog();
           od.enable();
         },
         context: this,
@@ -106,7 +106,7 @@ const WasabeeButton = WButton.extend({
         text: wX("NEWOP BUTTON"),
         callback: () => {
           this.disable();
-          const nb = new NewopDialog(this._map);
+          const nb = new NewopDialog();
           nb.enable();
         },
         context: this,
@@ -116,7 +116,7 @@ const WasabeeButton = WButton.extend({
         text: wX("CLEAROPS BUTTON"),
         callback: () => {
           this.disable();
-          const con = new ConfirmDialog(this._map, {
+          const con = new ConfirmDialog({
             title: wX("CLEAROPS BUTTON TITLE"),
             label: wX("CLEAROPS PROMPT"),
             callback: () => {

--- a/src/code/buttons/wasabeeButton.js
+++ b/src/code/buttons/wasabeeButton.js
@@ -116,10 +116,13 @@ const WasabeeButton = WButton.extend({
         text: wX("CLEAROPS BUTTON"),
         callback: () => {
           this.disable();
-          const con = new ConfirmDialog(this._map);
-          con.setup(wX("CLEAROPS BUTTON TITLE"), wX("CLEAROPS PROMPT"), () => {
-            resetOps();
-            setupLocalStorage();
+          const con = new ConfirmDialog(this._map, {
+            title: wX("CLEAROPS BUTTON TITLE"),
+            label: wX("CLEAROPS PROMPT"),
+            callback: () => {
+              resetOps();
+              setupLocalStorage();
+            },
           });
           con.enable();
         },

--- a/src/code/dialogs/about.js
+++ b/src/code/dialogs/about.js
@@ -1,23 +1,11 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 // This file documents the minimum requirements of a dialog in wasabee
 const AboutDialog = WDialog.extend({
   // not strictly necessary, but good style
   statics: {
     TYPE: "about",
-  },
-
-  // every leaflet class ought to have an initialize,
-  // inputs defined by leaflet, window.map is defined by IITC
-  // options can extended by callers
-  initialize: function (map = window.map, options) {
-    // always define type, it is used by the parent classes
-    this.type = AboutDialog.TYPE;
-    // call the parent classes initialize as well
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: AboutDialog.TYPE });
   },
 
   // WDialog is a leaflet L.Handler, which takes add/removeHooks

--- a/src/code/dialogs/about.js
+++ b/src/code/dialogs/about.js
@@ -21,11 +21,6 @@ const AboutDialog = WDialog.extend({
     }
   },
 
-  removeHooks: function () {
-    // put any post close teardown here
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   // define our work in _displayDialog
   _displayDialog: function () {
     // use leaflet's DOM object creation, not bare DOM or Jquery

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -12,10 +12,6 @@ const AgentDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: async function () {
     const html = L.DomUtil.create("div", null);
     const agent = L.DomUtil.create("div", null, html);

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -1,6 +1,5 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import WasabeeAgent from "../agent";
 
 const AgentDialog = WDialog.extend({
@@ -9,10 +8,8 @@ const AgentDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = AgentDialog.TYPE;
     this._gid = options.gid;
     WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: AgentDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -7,6 +7,10 @@ const AgentDialog = WDialog.extend({
     TYPE: "agent",
   },
 
+  options: {
+    // gid
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -7,11 +7,6 @@ const AgentDialog = WDialog.extend({
     TYPE: "agent",
   },
 
-  initialize: function (map = window.map, options) {
-    this._gid = options.gid;
-    WDialog.prototype.initialize.call(this, map, options);
-  },
-
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
@@ -26,7 +21,7 @@ const AgentDialog = WDialog.extend({
     const agent = L.DomUtil.create("div", null, html);
 
     try {
-      const data = await WasabeeAgent.waitGet(this._gid);
+      const data = await WasabeeAgent.waitGet(this.options.gid);
       const name = L.DomUtil.create("h2", "enl, wasabee-agent-label", agent);
       name.textContent = data.name;
       const vLabel = L.DomUtil.create("label", null, agent);

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -13,7 +13,6 @@ const AssignDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._setup();
     this._displayDialog();

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -18,7 +18,6 @@ const AssignDialog = WDialog.extend({
 
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
-    this._setup();
     this._displayDialog();
   },
 
@@ -27,6 +26,10 @@ const AssignDialog = WDialog.extend({
     buttons[wX("OK")] = () => {
       this._dialog.dialog("close");
     };
+
+    // create container then setup asynchronously
+    this._html = L.DomUtil.create("div", "container");
+    this._setup();
 
     this._dialog = window.dialog({
       title: this._name,
@@ -47,7 +50,6 @@ const AssignDialog = WDialog.extend({
     const operation = getSelectedOperation();
     this._dialog = null;
     this._targetID = target.ID;
-    this._html = L.DomUtil.create("div", null);
     const divtitle = L.DomUtil.create("div", "desc", this._html);
     const menu = await this._getAgentMenu(target.assignedTo);
 

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -12,6 +12,10 @@ const AssignDialog = WDialog.extend({
     TYPE: "assignDialog",
   },
 
+  options: {
+    // target,
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._setup();

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -5,18 +5,11 @@ import WasabeeAnchor from "../anchor";
 import WasabeeMe from "../me";
 import WasabeeTeam from "../team";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { getSelectedOperation } from "../selectedOp";
 
 const AssignDialog = WDialog.extend({
   statics: {
     TYPE: "assignDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = AssignDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: AssignDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -18,10 +18,6 @@ const AssignDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -15,6 +15,7 @@ const AssignDialog = WDialog.extend({
   addHooks: function () {
     if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
+    this._setup();
     this._displayDialog();
   },
 
@@ -42,7 +43,8 @@ const AssignDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  setup: async function (target) {
+  _setup: async function () {
+    const target = this.options.target;
     const operation = getSelectedOperation();
     this._dialog = null;
     this._targetID = target.ID;

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -17,7 +17,6 @@ const AuthDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },
@@ -143,7 +142,7 @@ const AuthDialog = WDialog.extend({
     changeServerButton.textContent = wX("CHANGE SERVER");
     L.DomEvent.on(changeServerButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const serverDialog = new PromptDialog(window.map, {
+      const serverDialog = new PromptDialog({
         title: wX("CHANGE SERVER"),
         label: wX("CHANGE SERVER PROMPT"),
         callback: () => {
@@ -163,7 +162,7 @@ const AuthDialog = WDialog.extend({
     oneTimeButton.textContent = "One Time Token Login";
     L.DomEvent.on(oneTimeButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const ottDialog = new PromptDialog(window.map, {
+      const ottDialog = new PromptDialog({
         title: "One Time Token",
         label: "One Time Token",
         callback: async () => {

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -16,12 +16,6 @@ const AuthDialog = WDialog.extend({
     TYPE: "authDialog",
   },
 
-  initialize: function (map = window.map, options) {
-    this.type = AuthDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: AuthDialog.TYPE });
-  },
-
   addHooks: function () {
     if (!this._map) return;
     WDialog.prototype.addHooks.call(this);

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -143,20 +143,19 @@ const AuthDialog = WDialog.extend({
     changeServerButton.textContent = wX("CHANGE SERVER");
     L.DomEvent.on(changeServerButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const serverDialog = new PromptDialog();
-      serverDialog.setup(
-        wX("CHANGE SERVER"),
-        wX("CHANGE SERVER PROMPT"),
-        () => {
+      const serverDialog = new PromptDialog(window.map, {
+        title: wX("CHANGE SERVER"),
+        label: wX("CHANGE SERVER PROMPT"),
+        callback: () => {
           if (serverDialog.inputField.value) {
             SetWasabeeServer(serverDialog.inputField.value);
             this._server.textContent = GetWasabeeServer();
             WasabeeMe.purge();
           }
-        }
-      );
-      serverDialog.current = GetWasabeeServer();
-      serverDialog.placeholder = "https://am.wasabee.rocks";
+        },
+        current: GetWasabeeServer(),
+        placeholder: "https://am.wasabee.rocks",
+      });
       serverDialog.enable();
     });
 
@@ -164,24 +163,26 @@ const AuthDialog = WDialog.extend({
     oneTimeButton.textContent = "One Time Token Login";
     L.DomEvent.on(oneTimeButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const ottDialog = new PromptDialog();
-      ottDialog.setup("One Time Token", "One Time Token", async () => {
-        if (ottDialog.inputField.value) {
-          try {
-            await oneTimeToken(ottDialog.inputField.value);
-            const newme = await WasabeeMe.waitGet(true);
-            newme.store();
-            this._dialog.dialog("close");
-            fullSync();
-            postToFirebase({ id: "wasabeeLogin", method: "One Time Token" });
-          } catch (e) {
-            console.error(e);
-            alert(e.toString());
+      const ottDialog = new PromptDialog(window.map, {
+        title: "One Time Token",
+        label: "One Time Token",
+        callback: async () => {
+          if (ottDialog.inputField.value) {
+            try {
+              await oneTimeToken(ottDialog.inputField.value);
+              const newme = await WasabeeMe.waitGet(true);
+              newme.store();
+              this._dialog.dialog("close");
+              fullSync();
+              postToFirebase({ id: "wasabeeLogin", method: "One Time Token" });
+            } catch (e) {
+              console.error(e);
+              alert(e.toString());
+            }
           }
-        }
+        },
+        placeholder: "smurf-tears-4twn",
       });
-      // ott.current= "";
-      ottDialog.placeholder = "smurf-tears-4twn";
       ottDialog.enable();
     });
 

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -21,10 +21,6 @@ const AuthDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   randomTip: function () {
     const lang = getLanguage();
     if (!window.plugin.wasabee.static.tips[lang]) return;

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -6,7 +6,6 @@ import StarburstDialog from "../dialogs/starburst";
 import OnionfieldDialog from "../dialogs/onionfield";
 import HomogeneousDialog from "../dialogs/homogeneous";
 import MadridDialog from "../dialogs/madrid";
-import { postToFirebase } from "../firebaseSupport";
 
 // This file documents the minimum requirements of a dialog in wasabee
 const AutodrawsDialog = WDialog.extend({
@@ -16,7 +15,6 @@ const AutodrawsDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    postToFirebase({ id: "analytics", action: AutodrawsDialog.TYPE });
     this._map = map;
     this.menuItems = [
       {
@@ -69,7 +67,6 @@ const AutodrawsDialog = WDialog.extend({
       },
     ];
 
-    this.type = AutodrawsDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
   },
 

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -77,10 +77,6 @@ const AutodrawsDialog = WDialog.extend({
     }
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const html = L.DomUtil.create("div", "container");
     for (const i of this.menuItems) {

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -14,14 +14,14 @@ const AutodrawsDialog = WDialog.extend({
     TYPE: "autodraws",
   },
 
-  initialize: function (map = window.map, options) {
-    this._map = map;
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
     this.menuItems = [
       {
         text: wX("MM"),
         callback: () => {
           this._dialog.dialog("close");
-          const mm = new MultimaxButtonControl(this._map);
+          const mm = new MultimaxButtonControl();
           mm.enable();
         },
       },
@@ -29,7 +29,7 @@ const AutodrawsDialog = WDialog.extend({
         text: wX("MAX"),
         callback: () => {
           this._dialog.dialog("close");
-          const ff = new FanfieldDialog(this._map);
+          const ff = new FanfieldDialog();
           ff.enable();
         },
       },
@@ -37,7 +37,7 @@ const AutodrawsDialog = WDialog.extend({
         text: wX("STARBURST"),
         callback: () => {
           this._dialog.dialog("close");
-          const sb = new StarburstDialog(this._map);
+          const sb = new StarburstDialog();
           sb.enable();
         },
       },
@@ -45,7 +45,7 @@ const AutodrawsDialog = WDialog.extend({
         text: wX("ONION_WAS_TAKEN"),
         callback: () => {
           this._dialog.dialog("close");
-          const o = new OnionfieldDialog(this._map);
+          const o = new OnionfieldDialog();
           o.enable();
         },
       },
@@ -53,7 +53,7 @@ const AutodrawsDialog = WDialog.extend({
         text: wX("HG"),
         callback: () => {
           this._dialog.dialog("close");
-          const h = new HomogeneousDialog(this._map);
+          const h = new HomogeneousDialog();
           h.enable();
         },
       },
@@ -61,13 +61,11 @@ const AutodrawsDialog = WDialog.extend({
         text: wX("MADRID_WAS_TAKEN"),
         callback: () => {
           this._dialog.dialog("close");
-          const m = new MadridDialog(this._map);
+          const m = new MadridDialog();
           m.enable();
         },
       },
     ];
-
-    WDialog.prototype.initialize.call(this, map, options);
   },
 
   addHooks: function () {

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -1,6 +1,6 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import MultimaxButtonControl from "../dialogs/multimaxDialog";
+import MultimaxDialog from "../dialogs/multimaxDialog";
 import FanfieldDialog from "../dialogs/fanfield";
 import StarburstDialog from "../dialogs/starburst";
 import OnionfieldDialog from "../dialogs/onionfield";
@@ -21,7 +21,7 @@ const AutodrawsDialog = WDialog.extend({
         text: wX("MM"),
         callback: () => {
           this._dialog.dialog("close");
-          const mm = new MultimaxButtonControl();
+          const mm = new MultimaxDialog();
           mm.enable();
         },
       },

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -9,17 +9,10 @@ import {
 } from "../uiCommands";
 import wX from "../wX";
 import TrawlDialog from "./trawl";
-import { postToFirebase } from "../firebaseSupport";
 
 const BlockerList = WDialog.extend({
   statics: {
     TYPE: "blockerList",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = BlockerList.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: BlockerList.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -16,7 +16,6 @@ const BlockerList = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.blockerlistUpdate, this);
     window.map.on("wasabeeCrosslinksDone", this.blockerlistUpdate, this);

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -204,8 +204,7 @@ const OperationChecklistDialog = WDialog.extend({
             // XXX should be writable op
             L.DomEvent.on(cell, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const ad = new AssignDialog();
-              ad.setup(thing);
+              const ad = new AssignDialog(window.map, { target: thing });
               ad.enable();
             });
           }

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -222,8 +222,10 @@ const OperationChecklistDialog = WDialog.extend({
           a.textContent = wX(value);
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const sd = new StateDialog();
-            sd.setup(thing, operation.ID);
+            const sd = new StateDialog(window.map, {
+              target: thing,
+              opID: operation.ID,
+            });
             sd.enable();
           });
         },

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -140,8 +140,7 @@ const OperationChecklistDialog = WDialog.extend({
           if (thing instanceof WasabeeMarker) {
             L.DomEvent.on(cell, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const ch = new MarkerChangeDialog();
-              ch.setup(thing);
+              const ch = new MarkerChangeDialog(window.map, { marker: thing });
               ch.enable();
             });
           }

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -15,17 +15,10 @@ import {
 import { getSelectedOperation } from "../selectedOp";
 import WasabeeMe from "../me";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const OperationChecklistDialog = WDialog.extend({
   statics: {
     TYPE: "operationChecklist",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = OperationChecklistDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: OperationChecklistDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -140,7 +140,7 @@ const OperationChecklistDialog = WDialog.extend({
           if (thing instanceof WasabeeMarker) {
             L.DomEvent.on(cell, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const ch = new MarkerChangeDialog(window.map, { marker: thing });
+              const ch = new MarkerChangeDialog({ marker: thing });
               ch.enable();
             });
           }
@@ -175,7 +175,7 @@ const OperationChecklistDialog = WDialog.extend({
           comment.textContent = value;
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const scd = new SetCommentDialog(window.map, {
+            const scd = new SetCommentDialog({
               target: thing,
               operation: operation,
             });
@@ -205,7 +205,7 @@ const OperationChecklistDialog = WDialog.extend({
             // XXX should be writable op
             L.DomEvent.on(cell, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const ad = new AssignDialog(window.map, { target: thing });
+              const ad = new AssignDialog({ target: thing });
               ad.enable();
             });
           }
@@ -222,7 +222,7 @@ const OperationChecklistDialog = WDialog.extend({
           a.textContent = wX(value);
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const sd = new StateDialog(window.map, {
+            const sd = new StateDialog({
               target: thing,
               opID: operation.ID,
             });

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -175,8 +175,10 @@ const OperationChecklistDialog = WDialog.extend({
           comment.textContent = value;
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const scd = new SetCommentDialog(window.map);
-            scd.setup(thing, operation);
+            const scd = new SetCommentDialog(window.map, {
+              target: thing,
+              operation: operation,
+            });
             scd.enable();
           });
         },

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -11,6 +11,8 @@ const ConfirmDialog = WDialog.extend({
   options: {
     title: wX("NO_TITLE"),
     label: wX("NO_LABEL"),
+    // callback,
+    // cancelCallback
   },
 
   addHooks: function () {

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -8,10 +8,9 @@ const ConfirmDialog = WDialog.extend({
     TYPE: "confirmDialog",
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
-    this._title = wX("NO_TITLE");
-    this._label = wX("NO_LABEL");
+  options: {
+    title: wX("NO_TITLE"),
+    label: wX("NO_LABEL"),
   },
 
   addHooks: function () {
@@ -22,7 +21,7 @@ const ConfirmDialog = WDialog.extend({
       "true"
     ) {
       console.log("expert mode: skipping dialog display");
-      if (this._callback) this._callback();
+      if (this.options.callback) this.options.callback();
     } else {
       this._displayDialog();
     }
@@ -38,16 +37,16 @@ const ConfirmDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      if (this._callback) this._callback();
+      if (this.options.callback) this.options.callback();
       this._dialog.dialog("close");
     };
     buttons[wX("CANCEL")] = () => {
-      if (this._cancelCallback) this._cancelCallback();
+      if (this.options.cancelCallback) this.options.cancelCallback();
       this._dialog.dialog("close");
     };
 
     this._dialog = window.dialog({
-      title: this._title,
+      title: this.options.title,
       html: this._buildContent(),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-confirm",
@@ -60,19 +59,12 @@ const ConfirmDialog = WDialog.extend({
     });
   },
 
-  setup: function (title, label, callback, cancelCallback) {
-    this._title = title;
-    this._label = label;
-    if (callback) this._callback = callback;
-    if (cancelCallback) this._cancelCallback = cancelCallback;
-  },
-
   _buildContent: function () {
     const content = L.DomUtil.create("div", "title");
-    if (typeof this._label == "string") {
-      content.textContent = this._label;
+    if (typeof this.options.label == "string") {
+      content.textContent = this.options.label;
     } else {
-      content.appendChild(this._label);
+      content.appendChild(this.options.label);
     }
     return content;
   },

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -1,6 +1,5 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 // generic confirmation screen w/ ok and cancel buttons
 
@@ -10,11 +9,9 @@ const ConfirmDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = ConfirmDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this._title = wX("NO_TITLE");
     this._label = wX("NO_LABEL");
-    postToFirebase({ id: "analytics", action: ConfirmDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -14,7 +14,6 @@ const ConfirmDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     if (
       localStorage[window.plugin.wasabee.static.constants.EXPERT_MODE_KEY] ==
@@ -33,8 +32,6 @@ const ConfirmDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     const buttons = {};
     buttons[wX("OK")] = () => {
       if (this.options.callback) this.options.callback();

--- a/src/code/dialogs/defensiveKeysDialog.js
+++ b/src/code/dialogs/defensiveKeysDialog.js
@@ -4,17 +4,10 @@ import WasabeeMe from "../me";
 import { dKeyPromise } from "../server";
 import wX from "../wX";
 import WasabeeDList from "./wasabeeDlist";
-import { postToFirebase } from "../firebaseSupport";
 
 const DefensiveKeysDialog = WDialog.extend({
   statics: {
     TYPE: "defensiveKeysDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = DefensiveKeysDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: DefensiveKeysDialog.TYPE });
   },
 
   addHooks: async function () {

--- a/src/code/dialogs/defensiveKeysDialog.js
+++ b/src/code/dialogs/defensiveKeysDialog.js
@@ -11,7 +11,6 @@ const DefensiveKeysDialog = WDialog.extend({
   },
 
   addHooks: async function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._me = await WasabeeMe.waitGet();
     this._pch = (portal) => {

--- a/src/code/dialogs/exportDialog.js
+++ b/src/code/dialogs/exportDialog.js
@@ -1,18 +1,11 @@
 import { WDialog } from "../leafletClasses";
 import { getSelectedOperation } from "../selectedOp";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 // export screen
 const ExportDialog = WDialog.extend({
   statics: {
     TYPE: "exportDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = ExportDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: ExportDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/exportDialog.js
+++ b/src/code/dialogs/exportDialog.js
@@ -9,7 +9,6 @@ const ExportDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },

--- a/src/code/dialogs/exportDialog.js
+++ b/src/code/dialogs/exportDialog.js
@@ -13,10 +13,6 @@ const ExportDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const operation = getSelectedOperation();
     const buttons = {};

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -5,7 +5,6 @@ import { greatCircleArcIntersect, GeodesicLine } from "../crosslinks";
 import WasabeeLink from "../link";
 import { clearAllLinks, getAllPortalsOnScreen } from "../uiCommands";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const FanfieldDialog = WDialog.extend({
   statics: {
@@ -16,7 +15,6 @@ const FanfieldDialog = WDialog.extend({
     if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
-    postToFirebase({ id: "analytics", action: FanfieldDialog.TYPE });
   },
 
   removeHooks: function () {
@@ -140,7 +138,6 @@ const FanfieldDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = FanfieldDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this.title = wX("FAN_FIELD3");
     this.label = wX("FAN_FIELD3");

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -16,10 +16,6 @@ const FanfieldDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const container = L.DomUtil.create("div", "container");
     const description = L.DomUtil.create("div", "desc", container);

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -12,7 +12,6 @@ const FanfieldDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },
@@ -22,8 +21,6 @@ const FanfieldDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     const container = L.DomUtil.create("div", "container");
     const description = L.DomUtil.create("div", "desc", container);
     description.textContent = wX("SELECT_FAN_PORTALS");
@@ -137,8 +134,8 @@ const FanfieldDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
     this.title = wX("FAN_FIELD3");
     this.label = wX("FAN_FIELD3");
     let p = localStorage["wasabee-anchor-1"];

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -34,8 +34,6 @@ const HomogeneousDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     const container = L.DomUtil.create("div", "container");
     const description2 = L.DomUtil.create("div", "desc", container);
     description2.textContent = wX("H-GEN_INST");
@@ -196,8 +194,8 @@ const HomogeneousDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
     this.title = "Homogeneous";
     this.label = "Homogeneous";
     this._operation = getSelectedOperation();
@@ -368,7 +366,7 @@ const HomogeneousDialog = WDialog.extend({
     const center = this._getCenter(one, two, three);
     for (const p of portalsCovered) {
       if (p == one.id || p == two.id || p == three.id) continue;
-      const cDist = this._map.distance(center, p.latLng || p._latlng);
+      const cDist = window.map.distance(center, p.latLng || p._latlng);
       m.set(cDist, p);
     }
     // sort by distance to centeroid the field
@@ -808,12 +806,12 @@ const HomogeneousDialog = WDialog.extend({
   },
 
   _getCenter: function (a, b, c) {
-    const A = this._map.project(a.latLng || a._latlng);
-    const B = this._map.project(b.latLng || b._latlng);
-    const C = this._map.project(c.latLng || c._latlng);
+    const A = window.map.project(a.latLng || a._latlng);
+    const B = window.map.project(b.latLng || b._latlng);
+    const C = window.map.project(c.latLng || c._latlng);
 
     const point = L.point((A.x + B.x + C.x) / 3, (A.y + B.y + C.y) / 3);
-    return this._map.unproject(point);
+    return window.map.unproject(point);
   },
 
   _fieldCovers: function (a, b, c, p) {

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -9,7 +9,6 @@ import {
   testPortal,
 } from "../uiCommands";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const HomogeneousDialog = WDialog.extend({
   statics: {
@@ -199,7 +198,6 @@ const HomogeneousDialog = WDialog.extend({
 
   initialize: function (map = window.map, options) {
     WDialog.prototype.initialize.call(this, map, options);
-    this.type = HomogeneousDialog.TYPE;
     this.title = "Homogeneous";
     this.label = "Homogeneous";
     this._operation = getSelectedOperation();
@@ -212,7 +210,6 @@ const HomogeneousDialog = WDialog.extend({
 
     this._urp = testPortal();
     this._failed = 0;
-    postToFirebase({ id: "analytics", action: HomogeneousDialog.TYPE });
   },
 
   hfield: function () {

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -18,19 +18,12 @@ const HomogeneousDialog = WDialog.extend({
   addHooks: function () {
     this._layerGroup = new L.LayerGroup();
     window.addLayerGroup("Wasabee H-G Debug", this._layerGroup, true);
-    window.map.on("wasabeeUIUpdate", this.uiupdate, this);
     this._displayDialog();
   },
 
   removeHooks: function () {
     window.removeLayerGroup(this._layerGroup);
-    window.map.off("wasabeeUIUpdate", this.uiupdate, this);
     WDialog.prototype.removeHooks.call(this);
-  },
-
-  uiupdate: function () {
-    // if the screen redraws, make sure we are using the correct operation
-    this._operation = getSelectedOperation();
   },
 
   _displayDialog: function () {
@@ -160,6 +153,7 @@ const HomogeneousDialog = WDialog.extend({
     this._redrawButton.style.display = "none";
     L.DomEvent.on(this._redrawButton, "click", (ev) => {
       L.DomEvent.stop(ev);
+      this._operation = getSelectedOperation();
       if (this._tree) this._draw.call(this);
     });
 
@@ -168,6 +162,7 @@ const HomogeneousDialog = WDialog.extend({
     drawButton.textContent = wX("HF_DRAW_BUTTON");
     L.DomEvent.on(drawButton, "click", (ev) => {
       L.DomEvent.stop(ev);
+      this._operation = getSelectedOperation();
       if (this._fullSearchCheck.checked) this.hdeepfield.call(this);
       else this.hfield.call(this);
     });
@@ -198,7 +193,6 @@ const HomogeneousDialog = WDialog.extend({
     WDialog.prototype.initialize.call(this, options);
     this.title = "Homogeneous";
     this.label = "Homogeneous";
-    this._operation = getSelectedOperation();
     let p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_ONE_KEY];
     if (p) this._anchorOne = new WasabeePortal(p);
     p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY];

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -22,10 +22,6 @@ const ImportDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const container = L.DomUtil.create("div", null);
     container.style.width = "420px";

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -3,18 +3,11 @@ import WasabeePortal from "../portal";
 import { WDialog } from "../leafletClasses";
 import OperationChecklistDialog from "./checklist";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { makeSelectedOperation } from "../selectedOp";
 
 const ImportDialog = WDialog.extend({
   statics: {
     TYPE: "importDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = ImportDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: ImportDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -11,7 +11,6 @@ const ImportDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     this._autoload = false;
     if (
       localStorage[window.plugin.wasabee.static.constants.AUTO_LOAD_FAKED] ===
@@ -28,8 +27,6 @@ const ImportDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     const container = L.DomUtil.create("div", null);
     container.style.width = "420px";
 
@@ -113,7 +110,7 @@ const ImportDialog = WDialog.extend({
       checklist.enable();
       // zoom to it
       // OR use pointTileDataRequest to try to load faked portals?
-      this._map.fitBounds(newop.mbr);
+      window.map.fitBounds(newop.mbr);
 
       return;
     }

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -20,16 +20,13 @@ const KeyListPortal = WDialog.extend({
     window.map.off("wasabeeUIUpdate", this.keyListUpdate, this);
   },
 
-  setup: function (portalID) {
-    this._portalID = portalID;
-    this._sortable = this.getSortable();
-  },
-
   _displayDialog: function () {
-    if (!this._portalID) {
+    if (!this.options.portalID) {
       this.disable();
       return;
     }
+
+    this._sortable = this.getSortable();
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -37,11 +34,11 @@ const KeyListPortal = WDialog.extend({
     };
 
     const op = getSelectedOperation();
-    const portal = op.getPortal(this._portalID);
+    const portal = op.getPortal(this.options.portalID);
 
     this._dialog = window.dialog({
       title: wX("PORTAL KEY LIST", portal.displayName),
-      html: this.getListDialogContent(this._portalID),
+      html: this.getListDialogContent(this.options.portalID),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-keylistportal",
       closeCallback: () => {
@@ -56,7 +53,7 @@ const KeyListPortal = WDialog.extend({
   keyListUpdate: function () {
     // handle operation changes gracefully
     const op = getSelectedOperation();
-    const portal = op.getPortal(this._portalID);
+    const portal = op.getPortal(this.options.portalID);
     if (portal == null) {
       // needs wX
       this._dialog("option", "title", "unknown portal");
@@ -64,7 +61,7 @@ const KeyListPortal = WDialog.extend({
       return;
     }
 
-    const table = this.getListDialogContent(this._portalID);
+    const table = this.getListDialogContent(this.options.portalID);
     this._dialog.html(table);
     this._dialog("option", "title", wX("PORTAL KEY LIST", portal.displayName));
   },

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -9,6 +9,10 @@ const KeyListPortal = WDialog.extend({
     TYPE: "keyListPortal",
   },
 
+  options: {
+    // portalID
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.keyListUpdate, this);

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -3,17 +3,10 @@ import Sortable from "../../lib/sortable";
 import WasabeeAgent from "../agent";
 import { getSelectedOperation } from "../selectedOp";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const KeyListPortal = WDialog.extend({
   statics: {
     TYPE: "keyListPortal",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = KeyListPortal.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: KeyListPortal.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -211,8 +211,7 @@ const KeysList = WDialog.extend({
   },
 
   showKeyByPortal: function (e) {
-    const klp = new KeyListPortal();
-    klp.setup(e.srcElement.name);
+    const klp = new KeyListPortal(window.map, { portalID: e.srcElement.name });
     klp.enable();
   },
 });

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -5,17 +5,10 @@ import WasabeeMe from "../me";
 import KeyListPortal from "./keyListPortal";
 import { getSelectedOperation } from "../selectedOp";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const KeysList = WDialog.extend({
   statics: {
     TYPE: "keysList",
-  },
-
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
-    this.type = KeysList.TYPE;
-    postToFirebase({ id: "analytics", action: KeysList.TYPE });
   },
 
   addHooks: async function () {

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -12,7 +12,6 @@ const KeysList = WDialog.extend({
   },
 
   addHooks: async function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     const operation = getSelectedOperation();
     this._opID = operation.ID;
@@ -211,7 +210,7 @@ const KeysList = WDialog.extend({
   },
 
   showKeyByPortal: function (e) {
-    const klp = new KeyListPortal(window.map, { portalID: e.srcElement.name });
+    const klp = new KeyListPortal({ portalID: e.srcElement.name });
     klp.enable();
   },
 });

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -26,10 +26,6 @@ const LinkDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const container = L.DomUtil.create("div", "container");
 

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -2,7 +2,6 @@ import { WDialog } from "../leafletClasses";
 import WasabeePortal from "../portal";
 import { getSelectedOperation } from "../selectedOp";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const LinkDialog = WDialog.extend({
   statics: {
@@ -10,7 +9,6 @@ const LinkDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = LinkDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
 
     let p =
@@ -20,7 +18,6 @@ const LinkDialog = WDialog.extend({
     if (p) this._anchor1 = new WasabeePortal(p);
     p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY];
     if (p) this._anchor2 = new WasabeePortal(p);
-    postToFirebase({ id: "analytics", action: LinkDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -8,8 +8,8 @@ const LinkDialog = WDialog.extend({
     TYPE: "linkDialog",
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
 
     let p =
       localStorage[window.plugin.wasabee.static.constants.LINK_SOURCE_KEY];
@@ -21,7 +21,6 @@ const LinkDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     // this._operation = getSelectedOperation();
     this._displayDialog();
@@ -32,7 +31,6 @@ const LinkDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
     const container = L.DomUtil.create("div", "container");
 
     const sourceLabel = L.DomUtil.create("label", null, container);

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -6,7 +6,6 @@ import ConfirmDialog from "./confirmDialog";
 import WasabeeAgent from "../agent";
 import wX from "../wX";
 // import WasabeeMe from "../me";
-import { postToFirebase } from "../firebaseSupport";
 import { getSelectedOperation } from "../selectedOp";
 // import WasabeeOp from "../operation";
 
@@ -16,13 +15,11 @@ const LinkListDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = LinkListDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this._title = wX("NO_TITLE");
     this._label = wX("NO_LABEL");
     this.placeholder = "";
     this.current = "";
-    postToFirebase({ id: "analytics", action: LinkListDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -16,46 +16,7 @@ const LinkListDialog = WDialog.extend({
 
   initialize: function (map = window.map, options) {
     WDialog.prototype.initialize.call(this, map, options);
-    this._title = wX("NO_TITLE");
-    this._label = wX("NO_LABEL");
-    this.placeholder = "";
-    this.current = "";
-  },
 
-  addHooks: function () {
-    if (!this._map) return;
-    WDialog.prototype.addHooks.call(this);
-    window.map.on("wasabeeUIUpdate", this.updateLinkList, this);
-    this._displayDialog();
-  },
-
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-    window.map.off("wasabeeUIUpdate", this.updateLinkList, this);
-  },
-
-  _displayDialog: function () {
-    const buttons = {};
-    buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
-    };
-
-    this._dialog = window.dialog({
-      title: this._portal.displayName + wX("LINKS2"),
-      html: this._table.table,
-      width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-linklist",
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
-      id: window.plugin.wasabee.static.dialogNames.linkList,
-    });
-    this._dialog.dialog("option", "buttons", buttons);
-  },
-
-  setup: function (UNUSED, portal) {
-    this._portal = portal;
     const operation = getSelectedOperation();
     this._opID = operation.ID;
     this._table = new Sortable();
@@ -182,7 +143,39 @@ const LinkListDialog = WDialog.extend({
       },
     ];
     this._table.sortBy = 0;
-    this._table.items = operation.getLinkListFromPortal(this._portal);
+    this._table.items = operation.getLinkListFromPortal(this.options.portal);
+  },
+
+  addHooks: function () {
+    if (!this._map) return;
+    WDialog.prototype.addHooks.call(this);
+    window.map.on("wasabeeUIUpdate", this.updateLinkList, this);
+    this._displayDialog();
+  },
+
+  removeHooks: function () {
+    WDialog.prototype.removeHooks.call(this);
+    window.map.off("wasabeeUIUpdate", this.updateLinkList, this);
+  },
+
+  _displayDialog: function () {
+    const buttons = {};
+    buttons[wX("OK")] = () => {
+      this._dialog.dialog("close");
+    };
+
+    this._dialog = window.dialog({
+      title: this.options.portal.displayName + wX("LINKS2"),
+      html: this._table.table,
+      width: "auto",
+      dialogClass: "wasabee-dialog wasabee-dialog-linklist",
+      closeCallback: () => {
+        this.disable();
+        delete this._dialog;
+      },
+      id: window.plugin.wasabee.static.dialogNames.linkList,
+    });
+    this._dialog.dialog("option", "buttons", buttons);
   },
 
   deleteLink: function (link) {
@@ -238,7 +231,7 @@ const LinkListDialog = WDialog.extend({
     const operation = getSelectedOperation();
     if (!this._enabled) return;
     if (this._opID == operation.ID) {
-      this._table.items = operation.getLinkListFromPortal(this._portal);
+      this._table.items = operation.getLinkListFromPortal(this.options.portal);
     } else {
       // the selected operation changed, just bail
       this._dialog.dialog("close");

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -14,6 +14,10 @@ const LinkListDialog = WDialog.extend({
     TYPE: "linkListDialog",
   },
 
+  options: {
+    // portal
+  },
+
   initialize: function (options) {
     WDialog.prototype.initialize.call(this, options);
 

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -14,8 +14,8 @@ const LinkListDialog = WDialog.extend({
     TYPE: "linkListDialog",
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
 
     const operation = getSelectedOperation();
     this._opID = operation.ID;
@@ -71,7 +71,7 @@ const LinkListDialog = WDialog.extend({
             comment.textContent = window.escapeHtmlSpecialChars(data);
             L.DomEvent.on(cell, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const scd = new SetCommentDialog(window.map, {
+              const scd = new SetCommentDialog({
                 target: link,
                 operation: operation,
               });
@@ -101,7 +101,7 @@ const LinkListDialog = WDialog.extend({
           if (operation.IsServerOp() && operation.IsWritableOp()) {
             L.DomEvent.on(a, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const ad = new AssignDialog(window.map, { target: link });
+              const ad = new AssignDialog({ target: link });
               ad.enable();
             });
           }
@@ -149,7 +149,6 @@ const LinkListDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.updateLinkList, this);
     this._displayDialog();
@@ -185,7 +184,7 @@ const LinkListDialog = WDialog.extend({
     prompt.textContent = wX("CONFIRM_DELETE");
     const operation = getSelectedOperation();
     prompt.appendChild(link.displayFormat(operation));
-    const con = new ConfirmDialog(window.map, {
+    const con = new ConfirmDialog({
       title: "Delete Link",
       label: prompt,
       callback: () => {

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -138,8 +138,7 @@ const LinkListDialog = WDialog.extend({
           if (operation.IsServerOp() && operation.IsWritableOp()) {
             L.DomEvent.on(a, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const ad = new AssignDialog();
-              ad.setup(link);
+              const ad = new AssignDialog(window.map, { target: link });
               ad.enable();
             });
           }

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -186,13 +186,16 @@ const LinkListDialog = WDialog.extend({
   },
 
   deleteLink: function (link) {
-    const con = new ConfirmDialog(window.map);
     const prompt = L.DomUtil.create("div");
     prompt.textContent = wX("CONFIRM_DELETE");
     const operation = getSelectedOperation();
     prompt.appendChild(link.displayFormat(operation));
-    con.setup("Delete Link", prompt, () => {
-      operation.removeLink(link.fromPortalId, link.toPortalId);
+    const con = new ConfirmDialog(window.map, {
+      title: "Delete Link",
+      label: prompt,
+      callback: () => {
+        operation.removeLink(link.fromPortalId, link.toPortalId);
+      },
     });
     con.enable();
   },

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -71,8 +71,10 @@ const LinkListDialog = WDialog.extend({
             comment.textContent = window.escapeHtmlSpecialChars(data);
             L.DomEvent.on(cell, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const scd = new SetCommentDialog(window.map);
-              scd.setup(link, operation);
+              const scd = new SetCommentDialog(window.map, {
+                target: link,
+                operation: operation,
+              });
               scd.enable();
             });
           }

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -17,8 +17,6 @@ const MadridDialog = MultimaxDialog.extend({
   },
 
   // addHooks inherited from MultimaxDialog
-  // removeHooks inherited from MultimaxDialog
-  // this._operation should be safe due to multimax.uiupdate();
   _displayDialog: function () {
     const container = L.DomUtil.create("div", "container");
     const description = L.DomUtil.create("div", "desc", container);
@@ -65,7 +63,7 @@ const MadridDialog = MultimaxDialog.extend({
       this._setOneDisplay.textContent = wX("NOT_SET");
     }
     L.DomEvent.on(setOneButton, "click", () => {
-      this._portalSetOne = getAllPortalsOnScreen(this._operation);
+      this._portalSetOne = getAllPortalsOnScreen(getSelectedOperation());
       // XXX this is not enough, need to cache them in case IITC purges them
       this._setOneDisplay.textContent = wX(
         "PORTAL_COUNT",
@@ -114,7 +112,7 @@ const MadridDialog = MultimaxDialog.extend({
       this._setTwoDisplay.textContent = wX("NOT_SET");
     }
     L.DomEvent.on(setTwoButton, "click", () => {
-      this._portalSetTwo = getAllPortalsOnScreen(this._operation);
+      this._portalSetTwo = getAllPortalsOnScreen(getSelectedOperation());
       // XXX cache
       this._setTwoDisplay.textContent = wX(
         "PORTAL_COUNT",
@@ -141,7 +139,7 @@ const MadridDialog = MultimaxDialog.extend({
       this._setThreeDisplay.textContent = wX("NOT_SET");
     }
     L.DomEvent.on(setThreeButton, "click", () => {
-      this._portalSetThree = getAllPortalsOnScreen(this._operation);
+      this._portalSetThree = getAllPortalsOnScreen(getSelectedOperation());
       // XXX cache
       this._setThreeDisplay.textContent = wX(
         "PORTAL_COUNT",
@@ -176,6 +174,7 @@ const MadridDialog = MultimaxDialog.extend({
     const button = L.DomUtil.create("button", "drawb", container);
     button.textContent = wX("MADRID");
     L.DomEvent.on(button, "click", () => {
+      this._operation = getSelectedOperation();
       const total = this._balancedcheck.checked
         ? this.doBalancedMadrid.call(this)
         : this.doMadrid.call(this);
@@ -209,7 +208,6 @@ const MadridDialog = MultimaxDialog.extend({
     WDialog.prototype.initialize.call(this, options);
     this.title = wX("MADRID");
     this.label = wX("MADRID");
-    this._operation = getSelectedOperation(); // updated from multimax.uiupdate if necessary
     let p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_ONE_KEY];
     if (p) this._anchorOne = new WasabeePortal(p);
     p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY];

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -20,8 +20,6 @@ const MadridDialog = MultimaxDialog.extend({
   // removeHooks inherited from MultimaxDialog
   // this._operation should be safe due to multimax.uiupdate();
   _displayDialog: function () {
-    if (!this._map) return;
-
     const container = L.DomUtil.create("div", "container");
     const description = L.DomUtil.create("div", "desc", container);
     description.textContent = wX("SELECT_INSTRUCTIONS");
@@ -207,8 +205,8 @@ const MadridDialog = MultimaxDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
     this.title = wX("MADRID");
     this.label = wX("MADRID");
     this._operation = getSelectedOperation(); // updated from multimax.uiupdate if necessary
@@ -223,7 +221,7 @@ const MadridDialog = MultimaxDialog.extend({
     const portalsMap = new Map(portals.map((p) => [p.id, p]));
     const poset = this.buildPOSet(pOne, pTwo, portals);
     const sequence = this.longestSequence(poset, null, (a, b) =>
-      this._map.distance(portalsMap.get(a).latLng, portalsMap.get(b).latLng)
+      window.map.distance(portalsMap.get(a).latLng, portalsMap.get(b).latLng)
     );
 
     return sequence.map((id) => portalsMap.get(id));

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -8,7 +8,6 @@ import {
 } from "../uiCommands";
 import wX from "../wX";
 import MultimaxDialog from "./multimaxDialog";
-import { postToFirebase } from "../firebaseSupport";
 
 // now that the formerly external mm functions are in the class, some of the logic can be cleaned up
 // to not require passing values around when we can get them from this.XXX
@@ -209,7 +208,6 @@ const MadridDialog = MultimaxDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = MadridDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this.title = wX("MADRID");
     this.label = wX("MADRID");
@@ -219,7 +217,6 @@ const MadridDialog = MultimaxDialog.extend({
     p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY];
     if (p) this._anchorTwo = new WasabeePortal(p);
     this._urp = testPortal();
-    postToFirebase({ id: "analytics", action: MadridDialog.TYPE });
   },
 
   getSpine: function (pOne, pTwo, portals) {

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -104,11 +104,10 @@ const ManageTeamDialog = WDialog.extend({
           button.textContent = wX("REMOVE");
           L.DomEvent.on(button, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const con = new ConfirmDialog();
-            con.setup(
-              `${button.textContent}: ${obj.name}`,
-              `${button.textContent}: ${obj.name}?`,
-              async () => {
+            const con = new ConfirmDialog(window.map, {
+              title: `${button.textContent}: ${obj.name}`,
+              label: `${button.textContent}: ${obj.name}?`,
+              callback: async () => {
                 try {
                   await removeAgentFromTeamPromise(value, this._team.ID);
                 } catch (e) {
@@ -119,8 +118,8 @@ const ManageTeamDialog = WDialog.extend({
                   { reason: "manageTeamDialog" },
                   false
                 );
-              }
-            );
+              },
+            });
             con.enable();
           });
         },
@@ -274,11 +273,10 @@ const ManageTeamDialog = WDialog.extend({
     removeButton.textContent = wX("REMOVE");
     L.DomEvent.on(removeButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const cd = new ConfirmDialog();
-      cd.setup(
-        wX("REMOVE_TEAM_CONFIRM_TITLE", this._team.Name),
-        wX("REMOVE_TEAM_CONFIRM_LABEL", this._team.Name),
-        async () => {
+      const cd = new ConfirmDialog(window.map, {
+        title: wX("REMOVE_TEAM_CONFIRM_TITLE", this._team.Name),
+        label: wX("REMOVE_TEAM_CONFIRM_LABEL", this._team.Name),
+        callback: async () => {
           try {
             await deleteTeamPromise(this._team.ID);
             alert(`${this._team.Name} removed`);
@@ -288,8 +286,8 @@ const ManageTeamDialog = WDialog.extend({
             console.error(e);
             alert(e.toString());
           }
-        }
-      );
+        },
+      });
       cd.enable();
     });
 

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -23,6 +23,10 @@ const ManageTeamDialog = WDialog.extend({
     TYPE: "manageTeamDialog",
   },
 
+  options: {
+    // team
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.update, this);

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -16,18 +16,11 @@ import Sortable from "../../lib/sortable";
 import PromptDialog from "./promptDialog";
 import wX from "../wX";
 import ConfirmDialog from "./confirmDialog";
-import { postToFirebase } from "../firebaseSupport";
 
 // The update method here is the best so far, bring all the others up to this one
 const ManageTeamDialog = WDialog.extend({
   statics: {
     TYPE: "manageTeamDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = ManageTeamDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: ManageTeamDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -60,7 +60,7 @@ const ManageTeamDialog = WDialog.extend({
           button.textContent = value;
           L.DomEvent.on(button, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const squadDialog = new PromptDialog(window.map, {
+            const squadDialog = new PromptDialog({
               title: `Set Squad for ${obj.name}`,
               label: "Squad",
               callback: async () => {
@@ -103,7 +103,7 @@ const ManageTeamDialog = WDialog.extend({
           button.textContent = wX("REMOVE");
           L.DomEvent.on(button, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const con = new ConfirmDialog(window.map, {
+            const con = new ConfirmDialog({
               title: `${button.textContent}: ${obj.name}`,
               label: `${button.textContent}: ${obj.name}?`,
               callback: async () => {
@@ -278,7 +278,7 @@ const ManageTeamDialog = WDialog.extend({
     removeButton.textContent = wX("REMOVE");
     L.DomEvent.on(removeButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const cd = new ConfirmDialog(window.map, {
+      const cd = new ConfirmDialog({
         title: wX("REMOVE_TEAM_CONFIRM_TITLE", this.options.team.Name),
         label: wX("REMOVE_TEAM_CONFIRM_LABEL", this.options.team.Name),
         callback: async () => {

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -60,11 +60,10 @@ const ManageTeamDialog = WDialog.extend({
           button.textContent = value;
           L.DomEvent.on(button, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const squadDialog = new PromptDialog(window.map);
-            squadDialog.setup(
-              `Set Squad for ${obj.name}`,
-              "Squad",
-              async () => {
+            const squadDialog = new PromptDialog(window.map, {
+              title: `Set Squad for ${obj.name}`,
+              label: "Squad",
+              callback: async () => {
                 if (squadDialog.inputField.value) {
                   try {
                     await setAgentTeamSquadPromise(
@@ -87,10 +86,10 @@ const ManageTeamDialog = WDialog.extend({
                 } else {
                   alert(wX("INPUT_SQUAD_NAME"));
                 }
-              }
-            );
-            squadDialog.current = value;
-            squadDialog.placeholder = "boots";
+              },
+              current: value,
+              placeholder: "boots",
+            });
             squadDialog.enable();
           });
         },

--- a/src/code/dialogs/markerAddDialog.js
+++ b/src/code/dialogs/markerAddDialog.js
@@ -9,7 +9,6 @@ const MarkerAddDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     const context = this;
     this._pch = (portal) => {

--- a/src/code/dialogs/markerAddDialog.js
+++ b/src/code/dialogs/markerAddDialog.js
@@ -2,17 +2,10 @@ import { WDialog } from "../leafletClasses";
 import WasabeePortal from "../portal";
 import { getSelectedOperation } from "../selectedOp";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const MarkerAddDialog = WDialog.extend({
   statics: {
     TYPE: "markerButton",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = MarkerAddDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: MarkerAddDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -7,6 +7,10 @@ const MarkerChangeDialog = WDialog.extend({
     TYPE: "markerButton",
   },
 
+  options: {
+    // marker
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -1,17 +1,10 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { getSelectedOperation } from "../selectedOp";
 
 const MarkerChangeDialog = WDialog.extend({
   statics: {
     TYPE: "markerButton",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = MarkerChangeDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: MarkerChangeDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -17,15 +17,11 @@ const MarkerChangeDialog = WDialog.extend({
     WDialog.prototype.removeHooks.call(this);
   },
 
-  setup: function (target) {
-    this._marker = target;
-  },
-
   _displayDialog: function () {
     const operation = getSelectedOperation();
     const content = L.DomUtil.create("div", "content");
 
-    const portal = operation.getPortal(this._marker.portalId);
+    const portal = operation.getPortal(this.options.marker.portalId);
     const portalDisplay = L.DomUtil.create("div", "portal", content);
 
     portalDisplay.appendChild(portal.displayFormat(this._smallScreen));
@@ -37,9 +33,9 @@ const MarkerChangeDialog = WDialog.extend({
       const o = L.DomUtil.create("option", null, this._type);
       o.value = k;
       o.textContent = wX(k);
-      if (markers.has(k) && k != this._marker.type) o.disabled = true;
+      if (markers.has(k) && k != this.options.marker.type) o.disabled = true;
     }
-    this._type.value = this._marker.type;
+    this._type.value = this.options.marker.type;
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -47,8 +43,12 @@ const MarkerChangeDialog = WDialog.extend({
         window.plugin.wasabee.static.markerTypes.has(this._type.value) &&
         !markers.has(this._type.value)
       ) {
-        operation.removeMarker(this._marker);
-        operation.addMarker(this._type.value, portal, this._marker.comment);
+        operation.removeMarker(this.options.marker);
+        operation.addMarker(
+          this._type.value,
+          portal,
+          this.options.marker.comment
+        );
       }
       this._dialog.dialog("close");
     };

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -8,7 +8,6 @@ const MarkerChangeDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -12,10 +12,6 @@ const MarkerChangeDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const operation = getSelectedOperation();
     const content = L.DomUtil.create("div", "content");

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -19,7 +19,6 @@ const MarkerList = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     const operation = getSelectedOperation();
     this._opID = operation.ID;
@@ -100,7 +99,7 @@ const MarkerList = WDialog.extend({
           d.textContent = value;
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const ch = new MarkerChangeDialog(window.map, { marker: marker });
+            const ch = new MarkerChangeDialog({ marker: marker });
             ch.enable();
           });
         },
@@ -114,7 +113,7 @@ const MarkerList = WDialog.extend({
           comment.textContent = value;
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const scd = new SetCommentDialog(window.map, {
+            const scd = new SetCommentDialog({
               target: marker,
               operation: operation,
             });
@@ -139,7 +138,7 @@ const MarkerList = WDialog.extend({
           const assigned = L.DomUtil.create("a", "", cell);
           assigned.textContent = value;
           L.DomEvent.on(cell, "click", () => {
-            const ad = new AssignDialog(window.map, { target: agent });
+            const ad = new AssignDialog({ target: agent });
             ad.enable();
           });
         },

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -12,17 +12,10 @@ import {
   clearAllMarkers,
 } from "../uiCommands";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const MarkerList = WDialog.extend({
   statics: {
     TYPE: "markerList",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = MarkerList.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: MarkerList.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -138,8 +138,7 @@ const MarkerList = WDialog.extend({
           const assigned = L.DomUtil.create("a", "", cell);
           assigned.textContent = value;
           L.DomEvent.on(cell, "click", () => {
-            const ad = new AssignDialog();
-            ad.setup(agent);
+            const ad = new AssignDialog(window.map, { target: agent });
             ad.enable();
           });
         },

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -100,8 +100,7 @@ const MarkerList = WDialog.extend({
           d.textContent = value;
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const ch = new MarkerChangeDialog();
-            ch.setup(marker);
+            const ch = new MarkerChangeDialog(window.map, { marker: marker });
             ch.enable();
           });
         },

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -114,8 +114,10 @@ const MarkerList = WDialog.extend({
           comment.textContent = value;
           L.DomEvent.on(cell, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const scd = new SetCommentDialog(window.map);
-            scd.setup(marker, operation);
+            const scd = new SetCommentDialog(window.map, {
+              target: marker,
+              operation: operation,
+            });
             scd.enable();
           });
         },

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -1,18 +1,11 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import WasabeeOp from "../operation";
 import { getSelectedOperation, makeSelectedOperation } from "../selectedOp";
 
 const MergeDialog = WDialog.extend({
   statics: {
     TYPE: "megeDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = MergeDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: MergeDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -8,6 +8,11 @@ const MergeDialog = WDialog.extend({
     TYPE: "megeDialog",
   },
 
+  options: {
+    // opOwn
+    // opRemote
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -13,11 +13,6 @@ const MergeDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-    window.map.fire("wasabeeUIUpdate", { reason: "mergeDialog" }, false);
-  },
-
   _displayDialog: function () {
     const buttons = [];
     buttons.push({

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -35,9 +35,9 @@ const MergeDialog = WDialog.extend({
     buttons.push({
       text: "Replace",
       click: () => {
-        this._opRemote.store();
-        if (getSelectedOperation().ID == this._opRemote.ID)
-          makeSelectedOperation(this._opRemote.ID);
+        this.options.opRemote.store();
+        if (getSelectedOperation().ID == this.options.opRemote.ID)
+          makeSelectedOperation(this.options.opRemote.ID);
         this._dialog.dialog("close");
       },
     });
@@ -60,24 +60,18 @@ const MergeDialog = WDialog.extend({
     });
   },
 
-  setup: function (own, remote, callback) {
-    this._opOwn = own;
-    this._opRemote = remote;
-    this._opRebase = new WasabeeOp(remote);
-    if (callback) this._callback = callback;
-  },
-
   _buildContent: function () {
     const content = L.DomUtil.create("div", "container");
     const desc = L.DomUtil.create("div", "desc", content);
     desc.textContent =
       "Do you want to merge your change with the server OP or to replace the local version by the server version ?";
 
-    const changes = this._opOwn.changes();
-    const summary = this._opRebase.applyChanges(changes, this._opOwn);
+    this._opRebase = new WasabeeOp(this.options.opRemote);
+    const changes = this.options.opOwn.changes();
+    const summary = this._opRebase.applyChanges(changes, this.options.opOwn);
     this._opRebase.cleanAll();
-    this._opRebase.remoteChanged = this._opOwn.remoteChanged;
-    this._opRebase.localchanged = this._opOwn.localchanged;
+    this._opRebase.remoteChanged = this.options.opOwn.remoteChanged;
+    this._opRebase.localchanged = this.options.opOwn.localchanged;
 
     const rebaseMessage = L.DomUtil.create("div", null, content);
     rebaseMessage.append("Rebase summary:");

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -9,7 +9,6 @@ const MergeDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },
@@ -20,8 +19,6 @@ const MergeDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     const buttons = [];
     buttons.push({
       text: "Rebase",

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -33,8 +33,6 @@ const MultimaxDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     const container = L.DomUtil.create("div", "container");
     const description = L.DomUtil.create("div", "desc", container);
     description.textContent = wX("SELECT_INSTRUCTIONS");
@@ -134,8 +132,8 @@ const MultimaxDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
     this.title = wX("MULTI_M");
     this.label = wX("MULTI_M");
     let p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_ONE_KEY];
@@ -161,7 +159,7 @@ const MultimaxDialog = WDialog.extend({
     const poset = this.buildPOSet(pOne, pTwo, portals);
 
     const sequence = this.longestSequence(poset, null, (a, b) =>
-      this._map.distance(portalsMap.get(a).latLng, portalsMap.get(b).latLng)
+      window.map.distance(portalsMap.get(a).latLng, portalsMap.get(b).latLng)
     );
 
     if (base)

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -17,19 +17,8 @@ const MultimaxDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    window.map.on("wasabeeUIUpdate", this.uiupdate, this);
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
-  },
-
-  removeHooks: function () {
-    window.map.off("wasabeeUIUpdate", this.uiupdate, this);
-    WDialog.prototype.removeHooks.call(this);
-  },
-
-  uiupdate: function () {
-    // if the screen redraws, make sure we are on the current operation
-    this._operation = getSelectedOperation();
   },
 
   _displayDialog: function () {

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -8,7 +8,6 @@ import {
   clearAllLinks,
 } from "../uiCommands";
 import { greatCircleArcIntersect } from "../crosslinks";
-import { postToFirebase } from "../firebaseSupport";
 
 // now that the formerly external mm functions are in the class, some of the logic can be cleaned up
 // to not require passing values around when we can get them from this.XXX
@@ -136,7 +135,6 @@ const MultimaxDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = MultimaxDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this.title = wX("MULTI_M");
     this.label = wX("MULTI_M");
@@ -145,7 +143,6 @@ const MultimaxDialog = WDialog.extend({
     p = localStorage[window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY];
     if (p) this._anchorTwo = new WasabeePortal(p);
     this._urp = testPortal();
-    postToFirebase({ id: "analytics", action: MultimaxDialog.TYPE });
   },
 
   /*

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -81,10 +81,6 @@ const NewopDialog = WDialog.extend({
     });
     this._dialog.dialog("option", "buttons", buttons);
   },
-
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
 });
 
 export default NewopDialog;

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -34,26 +34,33 @@ const NewopDialog = WDialog.extend({
     L.DomEvent.on(addButton, "click", (ev) => {
       L.DomEvent.stop(ev);
       noHandler._dialog.dialog("close");
-      const addDialog = new PromptDialog(this._map);
-      addDialog.setup(wX("NEW_OP"), wX("SET_NEW_OP"), () => {
-        if (addDialog.inputField.value) {
-          const newop = new WasabeeOp({
-            creator: PLAYER.nickname,
-            name: addDialog.inputField.value,
-          });
-          newop.store();
-          makeSelectedOperation(newop.ID);
-          window.map.fire("wasabeeUIUpdate", { reason: "NewopDialog" }, false);
-          window.map.fire(
-            "wasabeeCrosslinks",
-            { reason: "NewopDialog" },
-            false
-          );
-        } else {
-          alert(wX("OP_NAME_UNSET"));
-        }
+      const addDialog = new PromptDialog(this._map, {
+        title: wX("NEW_OP"),
+        label: wX("SET_NEW_OP"),
+        callback: () => {
+          if (addDialog.inputField.value) {
+            const newop = new WasabeeOp({
+              creator: PLAYER.nickname,
+              name: addDialog.inputField.value,
+            });
+            newop.store();
+            makeSelectedOperation(newop.ID);
+            window.map.fire(
+              "wasabeeUIUpdate",
+              { reason: "NewopDialog" },
+              false
+            );
+            window.map.fire(
+              "wasabeeCrosslinks",
+              { reason: "NewopDialog" },
+              false
+            );
+          } else {
+            alert(wX("OP_NAME_UNSET"));
+          }
+        },
+        placeholder: wX("MUST_NOT_BE_EMPTY"),
       });
-      addDialog.placeholder = wX("MUST_NOT_BE_EMPTY");
       addDialog.enable();
     });
 

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -4,17 +4,10 @@ import ImportDialog from "./importDialog";
 import PromptDialog from "./promptDialog";
 import { makeSelectedOperation } from "../selectedOp";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const NewopDialog = WDialog.extend({
   statics: {
     TYPE: "newopButton",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = NewopDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: NewopDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -11,7 +11,6 @@ const NewopDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog(this);
   },
@@ -27,14 +26,14 @@ const NewopDialog = WDialog.extend({
     L.DomEvent.on(importButton, "click", (ev) => {
       L.DomEvent.stop(ev);
       noHandler._dialog.dialog("close");
-      const id = new ImportDialog(this._map, null);
+      const id = new ImportDialog(null);
       id.enable();
     });
 
     L.DomEvent.on(addButton, "click", (ev) => {
       L.DomEvent.stop(ev);
       noHandler._dialog.dialog("close");
-      const addDialog = new PromptDialog(this._map, {
+      const addDialog = new PromptDialog({
         title: wX("NEW_OP"),
         label: wX("SET_NEW_OP"),
         callback: () => {

--- a/src/code/dialogs/onionfield.js
+++ b/src/code/dialogs/onionfield.js
@@ -5,7 +5,6 @@ import { greatCircleArcIntersect } from "../crosslinks";
 import WasabeeLink from "../link";
 import { clearAllLinks, getAllPortalsOnScreen } from "../uiCommands";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const OnionfieldDialog = WDialog.extend({
   statics: {
@@ -103,14 +102,12 @@ const OnionfieldDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = OnionfieldDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this.title = "Onion/Rose";
     this.label = "Onion/Rose";
     const p =
       localStorage[window.plugin.wasabee.static.constants.ANCHOR_ONE_KEY];
     if (p) this._anchor = new WasabeePortal(p);
-    postToFirebase({ id: "analytics", action: OnionfieldDialog.TYPE });
   },
 
   onion: function () {

--- a/src/code/dialogs/onionfield.js
+++ b/src/code/dialogs/onionfield.js
@@ -28,8 +28,6 @@ const OnionfieldDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     const container = L.DomUtil.create("div", "container");
     const description = L.DomUtil.create("div", "desc", container);
     description.textContent = wX("SELECT_ONION_PORTALS");
@@ -101,8 +99,8 @@ const OnionfieldDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
     this.title = "Onion/Rose";
     this.label = "Onion/Rose";
     const p =
@@ -188,7 +186,7 @@ const OnionfieldDialog = WDialog.extend({
         continue;
       }
 
-      const pDist = this._map.distance(one.latLng, p.latLng);
+      const pDist = window.map.distance(one.latLng, p.latLng);
       m.set(pDist, p);
     }
     // sort by distance
@@ -339,9 +337,9 @@ const OnionfieldDialog = WDialog.extend({
   // angle a<bc in radians
   _angle: function (a, b, c) {
     // this formua finds b, swap a&b for our purposes
-    const A = this._map.project(b.latLng);
-    const B = this._map.project(a.latLng);
-    const C = this._map.project(c.latLng);
+    const A = window.map.project(b.latLng);
+    const B = window.map.project(a.latLng);
+    const C = window.map.project(c.latLng);
 
     const AB = Math.sqrt(Math.pow(B.x - A.x, 2) + Math.pow(B.y - A.y, 2));
     const BC = Math.sqrt(Math.pow(B.x - C.x, 2) + Math.pow(B.y - C.y, 2));

--- a/src/code/dialogs/onionfield.js
+++ b/src/code/dialogs/onionfield.js
@@ -12,19 +12,8 @@ const OnionfieldDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    // window.map.on("wasabeeUIUpdate", this.uiupdate, this);
-
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
-  },
-
-  removeHooks: function () {
-    // window.map.off("wasabeeUIUpdate", this.uiupdate, this);
-    WDialog.prototype.removeHooks.call(this);
-  },
-
-  uiupdate: function () {
-    // nothing needed, this._operation is (re)set at execute time
   },
 
   _displayDialog: function () {

--- a/src/code/dialogs/onlineAgentList.js
+++ b/src/code/dialogs/onlineAgentList.js
@@ -2,17 +2,10 @@ import { WDialog } from "../leafletClasses";
 import Sortable from "../../lib/sortable";
 // import WasabeeTeam from "../team";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const OnlineAgentList = WDialog.extend({
   statics: {
     TYPE: "OnlineAgentList",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = OnlineAgentList.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: OnlineAgentList.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/opPerms.js
+++ b/src/code/dialogs/opPerms.js
@@ -5,17 +5,10 @@ import WasabeeTeam from "../team";
 import WasabeeMe from "../me";
 import { addPermPromise, delPermPromise } from "../server";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const OpPermList = WDialog.extend({
   statics: {
     TYPE: "opPermList",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = OpPermList.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: OpPermList.TYPE });
   },
 
   addHooks: async function () {

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -157,7 +157,7 @@ const OpSettingDialog = WDialog.extend({
       L.DomEvent.stop(ev);
       // this should be moved to uiCommands
       const so = getSelectedOperation();
-      const con = new ConfirmDialog(window.map, {
+      const con = new ConfirmDialog({
         title: wX("CON_DEL", so.name),
         label: wX("YESNO_DEL", so.name),
         callback: async () => {
@@ -178,7 +178,7 @@ const OpSettingDialog = WDialog.extend({
             isFinite(mbr._southWest.lat) &&
             isFinite(mbr._northEast.lat)
           ) {
-            this._map.fitBounds(mbr);
+            window.map.fitBounds(mbr);
           }
         },
       });

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -156,28 +156,31 @@ const OpSettingDialog = WDialog.extend({
     L.DomEvent.on(deleteButton, "click", (ev) => {
       L.DomEvent.stop(ev);
       // this should be moved to uiCommands
-      const con = new ConfirmDialog(window.map);
       const so = getSelectedOperation();
-      con.setup(wX("CON_DEL", so.name), wX("YESNO_DEL", so.name), async () => {
-        if (so.IsServerOp() && so.IsOwnedOp() && so.IsOnCurrentServer()) {
-          try {
-            await deleteOpPromise(so.ID);
-            console.log("delete from server successful");
-          } catch (e) {
-            console.error(e);
-            alert(e.toString());
+      const con = new ConfirmDialog(window.map, {
+        title: wX("CON_DEL", so.name),
+        label: wX("YESNO_DEL", so.name),
+        callback: async () => {
+          if (so.IsServerOp() && so.IsOwnedOp() && so.IsOnCurrentServer()) {
+            try {
+              await deleteOpPromise(so.ID);
+              console.log("delete from server successful");
+            } catch (e) {
+              console.error(e);
+              alert(e.toString());
+            }
           }
-        }
-        removeOperation(so.ID);
-        const newop = changeOpIfNeeded();
-        const mbr = newop.mbr;
-        if (
-          mbr &&
-          isFinite(mbr._southWest.lat) &&
-          isFinite(mbr._northEast.lat)
-        ) {
-          this._map.fitBounds(mbr);
-        }
+          removeOperation(so.ID);
+          const newop = changeOpIfNeeded();
+          const mbr = newop.mbr;
+          if (
+            mbr &&
+            isFinite(mbr._southWest.lat) &&
+            isFinite(mbr._northEast.lat)
+          ) {
+            this._map.fitBounds(mbr);
+          }
+        },
       });
       con.enable();
     });

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -12,7 +12,6 @@ import {
 } from "../selectedOp";
 import OpPermList from "./opPerms";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { addToColorList } from "../skin";
 
 import { convertColorToHex } from "../auxiliar";
@@ -20,12 +19,6 @@ import { convertColorToHex } from "../auxiliar";
 const OpSettingDialog = WDialog.extend({
   statics: {
     TYPE: "opSettingDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = OpSettingDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: OpSettingDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -22,7 +22,6 @@ const OpsDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.update, this);
     this._displayDialog();
@@ -157,7 +156,7 @@ const OpsDialog = WDialog.extend({
               isFinite(mbr._southWest.lat) &&
               isFinite(mbr._northEast.lat)
             ) {
-              this._map.fitBounds(mbr);
+              window.map.fitBounds(mbr);
             }
           });
         }

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -11,7 +11,6 @@ import {
 } from "../selectedOp";
 import OpPermList from "./opPerms";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import WasabeeMe from "../me";
 import WasabeeAgent from "../agent";
 import GetWasabeeServer from "../server";
@@ -20,12 +19,6 @@ import { syncOp, deleteLocalOp } from "../uiCommands";
 const OpsDialog = WDialog.extend({
   statics: {
     TYPE: "opsDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = OpsDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: OpsDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -8,12 +8,11 @@ const PromptDialog = WDialog.extend({
     TYPE: "promptDialog",
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
-    this._title = wX("NO_TITLE"); // should never be displayed
-    this._label = wX("NO_LABEL"); // should never be displayed
-    this.placeholder = "";
-    this.current = "";
+  options: {
+    title: wX("NO_TITLE"), // should never be displayed
+    label: wX("NO_LABEL"), // should never be displayed
+    placeholder: "",
+    current: "",
   },
 
   addHooks: function () {
@@ -29,16 +28,16 @@ const PromptDialog = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      if (this._callback) this._callback();
+      if (this.options.callback) this.options.callback();
       this._dialog.dialog("close");
     };
     buttons[wX("CANCEL")] = () => {
-      if (this._cancelCallback) this._cancelCallback();
+      if (this.options.cancelCallback) this.options.cancelCallback();
       this._dialog.dialog("close");
     };
 
     this._dialog = window.dialog({
-      title: this._title,
+      title: this.options.title,
       html: this._buildContent(),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-prompt",
@@ -55,25 +54,18 @@ const PromptDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  setup: function (title, label, callback, cancelCallback) {
-    this._title = title;
-    this._label = label;
-    if (callback) this._callback = callback;
-    if (cancelCallback) this._cancelCallback = cancelCallback;
-  },
-
   _buildContent: function () {
     const content = L.DomUtil.create("div", "container");
-    if (typeof this._label == "string") {
+    if (typeof this.options.label == "string") {
       const label = L.DomUtil.create("label", null, content);
-      label.textContent = this._label;
+      label.textContent = this.options.label;
     } else {
-      content.appendChild(this._label);
+      content.appendChild(this.options.label);
     }
     this.inputField = L.DomUtil.create("input", null, content);
     this.inputField.id = "inputField";
-    this.inputField.placeholder = this.placeholder;
-    this.inputField.value = this.current;
+    this.inputField.placeholder = this.options.placeholder;
+    this.inputField.value = this.options.current;
     return content;
   },
 });

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -1,6 +1,5 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 // generic prompt screen
 
@@ -10,13 +9,11 @@ const PromptDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = PromptDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this._title = wX("NO_TITLE"); // should never be displayed
     this._label = wX("NO_LABEL"); // should never be displayed
     this.placeholder = "";
     this.current = "";
-    postToFirebase({ id: "analytics", action: PromptDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -20,10 +20,6 @@ const PromptDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -16,7 +16,6 @@ const PromptDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -13,6 +13,8 @@ const PromptDialog = WDialog.extend({
     label: wX("NO_LABEL"), // should never be displayed
     placeholder: "",
     current: "",
+    // callback
+    // cancelCallback
   },
 
   addHooks: function () {

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -15,6 +15,7 @@ const SendTargetDialog = WDialog.extend({
   addHooks: function () {
     if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
+    this._setup();
     this._displayDialog();
   },
 
@@ -42,28 +43,27 @@ const SendTargetDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  setup: async function (target) {
+  _setup: async function () {
     this._dialog = null;
-    this._target = target;
     this._html = L.DomUtil.create("div", null);
     const divtitle = L.DomUtil.create("div", "desc", this._html);
-    const menu = await this._getAgentMenu(target.assignedTo);
+    const menu = await this._getAgentMenu(this.options.target.assignedTo);
     this._name = wX("SEND TARGET AGENT");
     this._targettype = "ad hoc target";
 
     const operation = getSelectedOperation();
 
-    if (target instanceof WasabeeMarker) {
-      const portal = operation.getPortal(target.portalId);
-      this._targettype = target.type;
+    if (this.options.target instanceof WasabeeMarker) {
+      const portal = operation.getPortal(this.options.target.portalId);
+      this._targettype = this.options.target.type;
       divtitle.appendChild(portal.displayFormat(this._smallScreen));
       const t = L.DomUtil.create("label", null);
       t.textContent = wX("SEND TARGET AGENT");
       menu.prepend(t);
     }
 
-    if (target instanceof WasabeeAnchor) {
-      const portal = operation.getPortal(target.portalId);
+    if (this.options.target instanceof WasabeeAnchor) {
+      const portal = operation.getPortal(this.options.target.portalId);
       this._targettype = "anchor";
       divtitle.appendChild(portal.displayFormat(this._smallScreen));
       const t = L.DomUtil.create("label", null);
@@ -96,7 +96,7 @@ const SendTargetDialog = WDialog.extend({
 
     menu.addEventListener("change", async (ev) => {
       L.DomEvent.stop(ev);
-      const portal = operation.getPortal(this._target.portalId);
+      const portal = operation.getPortal(this.options.target.portalId);
       try {
         await targetPromise(menu.value, portal, this._targettype);
         this._dialog.dialog("close");

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -13,7 +13,6 @@ const SendTargetDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._setup();
     this._displayDialog();

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -18,10 +18,6 @@ const SendTargetDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -12,6 +12,10 @@ const SendTargetDialog = WDialog.extend({
     TYPE: "sendTargetDialog",
   },
 
+  options: {
+    // target
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._setup();

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -5,18 +5,11 @@ import WasabeeMe from "../me";
 import WasabeeTeam from "../team";
 import { targetPromise } from "../server";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { getSelectedOperation } from "../selectedOp";
 
 const SendTargetDialog = WDialog.extend({
   statics: {
     TYPE: "sendTargetDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = SendTargetDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: SendTargetDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -18,7 +18,6 @@ const SendTargetDialog = WDialog.extend({
 
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
-    this._setup();
     this._displayDialog();
   },
 
@@ -28,8 +27,11 @@ const SendTargetDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
+    this._html = L.DomUtil.create("div", null);
+    this._setup();
+
     this._dialog = window.dialog({
-      title: this._name,
+      title: wX("SEND TARGET AGENT"),
       html: this._html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-sendtarget",
@@ -43,11 +45,8 @@ const SendTargetDialog = WDialog.extend({
   },
 
   _setup: async function () {
-    this._dialog = null;
-    this._html = L.DomUtil.create("div", null);
     const divtitle = L.DomUtil.create("div", "desc", this._html);
     const menu = await this._getAgentMenu(this.options.target.assignedTo);
-    this._name = wX("SEND TARGET AGENT");
     this._targettype = "ad hoc target";
 
     const operation = getSelectedOperation();

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -45,10 +45,6 @@ export const SetCommentDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -9,6 +9,11 @@ export const SetCommentDialog = WDialog.extend({
     TYPE: "setCommentDialog",
   },
 
+  options: {
+    // target
+    // operation
+  },
+
   initialize: function (options) {
     WDialog.prototype.initialize.call(this, options);
 

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -5,36 +5,39 @@ import WasabeeMarker from "../marker";
 import wX from "../wX";
 
 export const SetCommentDialog = WDialog.extend({
-  setup: function (target, operation) {
-    this.operation = operation;
-    this.target = target;
+  statics: {
+    TYPE: "setCommentDialog",
+  },
 
-    if (target instanceof WasabeeLink) {
+  initialize: function (map = window.map, options) {
+    WDialog.prototype.initialize.call(this, map, options);
+
+    if (this.options.target instanceof WasabeeLink) {
       this.commentType = "link";
       this.dialogTitle = wX("SET_LCOMMENT");
-      this.portal = this.operation.getPortal(this.target.fmPortalId);
+      this.portal = this.options.operation.getPortal(
+        this.options.target.fmPortalId
+      );
     }
 
-    if (target instanceof WasabeeMarker) {
+    if (this.options.target instanceof WasabeeMarker) {
       this.commentType = "marker";
-      this.portal = this.operation.getPortal(this.target.portalId);
+      this.portal = this.options.operation.getPortal(
+        this.options.target.portalId
+      );
       this.dialogTitle = wX("SET_MCOMMENT", this.portal.displayName);
     }
 
-    if (target instanceof WasabeePortal) {
+    if (this.options.target instanceof WasabeePortal) {
       this.commentType = "portal";
-      this.dialogTitle = wX("SET_PCOMMENT", target.displayName);
-      this.portal = this.target;
+      this.dialogTitle = wX("SET_PCOMMENT", this.options.target.displayName);
+      this.portal = this.options.target;
     }
 
     if (!this.commentType) {
       console.log("comment dialog requested for unknown type");
-      console.log(target);
+      console.log(this.options.target);
     }
-  },
-
-  statics: {
-    TYPE: "setCommentDialog",
   },
 
   addHooks: function () {
@@ -76,13 +79,20 @@ export const SetCommentDialog = WDialog.extend({
     if (this.commentType == "link") {
       desc.textContent = wX("SET_LINK_COMMENT");
       desc.appendChild(
-        this.target.displayFormat(this.operation, this._smallScreen)
+        this.options.target.displayFormat(
+          this.options.operation,
+          this._smallScreen
+        )
       );
-      if (this.target.comment) input.value = this.target.comment;
+      if (this.options.target.comment)
+        input.value = this.options.target.comment;
       input.addEventListener(
         "change",
         () => {
-          this.operation.setLinkComment(this.target, input.value);
+          this.options.operation.setLinkComment(
+            this.options.target,
+            input.value
+          );
         },
         false
       );
@@ -90,13 +100,17 @@ export const SetCommentDialog = WDialog.extend({
 
     if (this.commentType == "marker") {
       desc.textContent = wX("SET_MARKER_COMMENT");
-      desc.appendChild(this.portal.displayFormat(this.operation));
+      desc.appendChild(this.portal.displayFormat(this.options.operation));
 
-      if (this.target.comment) input.value = this.target.comment;
+      if (this.options.target.comment)
+        input.value = this.options.target.comment;
       input.addEventListener(
         "change",
         () => {
-          this.operation.setMarkerComment(this.target, input.value);
+          this.options.operation.setMarkerComment(
+            this.options.target,
+            input.value
+          );
         },
         false
       );
@@ -110,7 +124,10 @@ export const SetCommentDialog = WDialog.extend({
       input.addEventListener(
         "change",
         () => {
-          this.operation.setPortalComment(this.target, input.value);
+          this.options.operation.setPortalComment(
+            this.options.target,
+            input.value
+          );
         },
         false
       );
@@ -121,7 +138,10 @@ export const SetCommentDialog = WDialog.extend({
       hardnessInput.addEventListener(
         "change",
         () => {
-          this.operation.setPortalHardness(this.target, hardnessInput.value);
+          this.options.operation.setPortalHardness(
+            this.options.target,
+            hardnessInput.value
+          );
         },
         false
       );

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -9,8 +9,8 @@ export const SetCommentDialog = WDialog.extend({
     TYPE: "setCommentDialog",
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
 
     if (this.options.target instanceof WasabeeLink) {
       this.commentType = "link";
@@ -41,7 +41,6 @@ export const SetCommentDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -3,7 +3,6 @@ import WasabeePortal from "../portal";
 import WasabeeLink from "../link";
 import WasabeeMarker from "../marker";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 export const SetCommentDialog = WDialog.extend({
   setup: function (target, operation) {
@@ -36,12 +35,6 @@ export const SetCommentDialog = WDialog.extend({
 
   statics: {
     TYPE: "setCommentDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = SetCommentDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: SetCommentDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -221,7 +221,7 @@ const SettingsDialog = WDialog.extend({
   },
 
   setServer: function () {
-    const serverDialog = new PromptDialog(window.map, {
+    const serverDialog = new PromptDialog({
       title: wX("CHANGE_WAS_SERVER"),
       label: wX("NEW_WAS_SERVER"),
       callback: () => {

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -221,16 +221,18 @@ const SettingsDialog = WDialog.extend({
   },
 
   setServer: function () {
-    const serverDialog = new PromptDialog(window.map);
-    serverDialog.setup(wX("CHANGE_WAS_SERVER"), wX("NEW_WAS_SERVER"), () => {
-      if (serverDialog.inputField.value) {
-        SetWasabeeServer(serverDialog.inputField.value);
-        WasabeeMe.purge();
-      }
+    const serverDialog = new PromptDialog(window.map, {
+      title: wX("CHANGE_WAS_SERVER"),
+      label: wX("NEW_WAS_SERVER"),
+      callback: () => {
+        if (serverDialog.inputField.value) {
+          SetWasabeeServer(serverDialog.inputField.value);
+          WasabeeMe.purge();
+        }
+      },
+      current: GetWasabeeServer(),
+      placeholder: window.plugin.wasabee.static.constants.SERVER_BASE_DEFAULT,
     });
-    serverDialog.current = GetWasabeeServer();
-    serverDialog.placeholder =
-      window.plugin.wasabee.static.constants.SERVER_BASE_DEFAULT;
     serverDialog.enable();
   },
 

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -4,7 +4,6 @@ import addButtons from "../addButtons";
 import WasabeeMe from "../me";
 import { GetWasabeeServer, SetWasabeeServer } from "../server";
 import PromptDialog from "./promptDialog";
-import { postToFirebase } from "../firebaseSupport";
 import SkinDialog from "./skinDialog";
 
 // This file documents the minimum requirements of a dialog in wasabee
@@ -12,17 +11,6 @@ const SettingsDialog = WDialog.extend({
   // not strictly necessary, but good style
   statics: {
     TYPE: "settings",
-  },
-
-  // every leaflet class ought to have an initialize,
-  // inputs defined by leaflet, window.map is defined by IITC
-  // options can extended by callers
-  initialize: function (map = window.map, options) {
-    // always define type, it is used by the parent classes
-    this.type = SettingsDialog.TYPE;
-    // call the parent classes initialize as well
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: SettingsDialog.TYPE });
   },
 
   // WDialog is a leaflet L.Handler, which takes add/removeHooks

--- a/src/code/dialogs/skinDialog.js
+++ b/src/code/dialogs/skinDialog.js
@@ -8,8 +8,8 @@ const SkinDialog = WDialog.extend({
     TYPE: "skinDialog",
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
 
     if (!window.plugin.wasabeeSkins) window.plugin.wasabeeSkins = {};
     this._skinSet = new Set(
@@ -18,7 +18,6 @@ const SkinDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },

--- a/src/code/dialogs/skinDialog.js
+++ b/src/code/dialogs/skinDialog.js
@@ -1,6 +1,5 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { changeSkin } from "../skin";
 import Sortable from "sortablejs";
 
@@ -10,9 +9,7 @@ const SkinDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = SkinDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: SkinDialog.TYPE });
 
     if (!window.plugin.wasabeeSkins) window.plugin.wasabeeSkins = {};
     this._skinSet = new Set(

--- a/src/code/dialogs/skinDialog.js
+++ b/src/code/dialogs/skinDialog.js
@@ -22,12 +22,6 @@ const SkinDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
-  update: function () {},
-
   _buildContent() {
     const container = L.DomUtil.create("div", "content");
 

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -10,7 +10,6 @@ const StarburstDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },
@@ -20,8 +19,6 @@ const StarburstDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    if (!this._map) return;
-
     //Instructions
     const container = L.DomUtil.create("div", "container");
     const description = L.DomUtil.create("div", "desc", container);
@@ -93,8 +90,8 @@ const StarburstDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
+  initialize: function (options) {
+    WDialog.prototype.initialize.call(this, options);
     this.title = wX("STARBURST");
     this.label = wX("STARBURST TITLE");
     const p =

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -14,10 +14,6 @@ const StarburstDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     //Instructions
     const container = L.DomUtil.create("div", "container");

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -3,7 +3,6 @@ import WasabeePortal from "../portal";
 import { getSelectedOperation } from "../selectedOp";
 import { clearAllLinks, getAllPortalsOnScreen } from "../uiCommands";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const StarburstDialog = WDialog.extend({
   statics: {
@@ -95,14 +94,12 @@ const StarburstDialog = WDialog.extend({
   },
 
   initialize: function (map = window.map, options) {
-    this.type = StarburstDialog.TYPE;
     WDialog.prototype.initialize.call(this, map, options);
     this.title = wX("STARBURST");
     this.label = wX("STARBURST TITLE");
     const p =
       localStorage[window.plugin.wasabee.static.constants.ANCHOR_ONE_KEY];
     if (p) this._anchor = new WasabeePortal(p);
-    postToFirebase({ id: "analytics", action: StarburstDialog.TYPE });
   },
 
   starburst: function () {

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -9,6 +9,11 @@ const StateDialog = WDialog.extend({
     TYPE: "stateDialog",
   },
 
+  options: {
+    // target
+    // opID
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._setup();

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -26,6 +26,9 @@ const StateDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
+    // for this._name and this._html
+    this._buildContent();
+
     this._dialog = window.dialog({
       title: this._name,
       html: this._html,
@@ -40,8 +43,7 @@ const StateDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  _setup: function () {
-    this._dialog = null;
+  _buildContent: function () {
     this._targetID = this.options.target.ID;
     this._html = L.DomUtil.create("div", null);
     const divtitle = L.DomUtil.create("div", "desc", this._html);
@@ -76,16 +78,6 @@ const StateDialog = WDialog.extend({
     }
 
     this._html.appendChild(menu);
-  },
-
-  _buildContent: function () {
-    const content = L.DomUtil.create("div");
-    if (typeof this._label == "string") {
-      content.textContent = this._label;
-    } else {
-      content.appendChild(this._label);
-    }
-    return content;
   },
 
   _getStateMenu: function (current) {

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -12,6 +12,7 @@ const StateDialog = WDialog.extend({
   addHooks: function () {
     if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
+    this._setup();
     this._displayDialog();
   },
 
@@ -39,32 +40,33 @@ const StateDialog = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  setup: function (target, opID) {
-    this._opID = opID; // used to determine if a different op has been selected, can probably be removed
+  _setup: function () {
     this._dialog = null;
-    this._targetID = target.ID;
+    this._targetID = this.options.target.ID;
     this._html = L.DomUtil.create("div", null);
     const divtitle = L.DomUtil.create("div", "desc", this._html);
-    const menu = this._getStateMenu(target);
+    const menu = this._getStateMenu(this.options.target);
 
     const operation = getSelectedOperation();
-    if (this._opID != operation.ID) {
+    if (this.options.opID != operation.ID) {
       console.log("operation changed between create/setup?!");
-      this._opID = operation.ID;
+      this.options.opID = operation.ID;
     }
 
-    if (target instanceof WasabeeLink) {
-      const portal = operation.getPortal(target.fromPortalId);
+    if (this.options.target instanceof WasabeeLink) {
+      const portal = operation.getPortal(this.options.target.fromPortalId);
       this._type = "Link";
       this._name = wX("LINK STATE PROMPT", portal.name);
-      divtitle.appendChild(target.displayFormat(operation, this._smallScreen));
+      divtitle.appendChild(
+        this.options.target.displayFormat(operation, this._smallScreen)
+      );
       const t = L.DomUtil.create("label", null);
       t.textContent = wX("LINK STATE");
       menu.prepend(t);
     }
 
-    if (target instanceof WasabeeMarker) {
-      const portal = operation.getPortal(target.portalId);
+    if (this.options.target instanceof WasabeeMarker) {
+      const portal = operation.getPortal(this.options.target.portalId);
       this._type = "Marker";
       this._name = wX("MARKER STATE PROMPT", portal.name);
       divtitle.appendChild(portal.displayFormat(this._smallScreen));
@@ -107,7 +109,7 @@ const StateDialog = WDialog.extend({
 
   setState: function (value) {
     const operation = getSelectedOperation();
-    if (this._opID != operation.ID) {
+    if (this.options.opID != operation.ID) {
       console.log("operation changed -- bailing");
       return;
     }

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -2,18 +2,11 @@ import { WDialog } from "../leafletClasses";
 import WasabeeLink from "../link";
 import WasabeeMarker from "../marker";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { getSelectedOperation } from "../selectedOp";
 
 const StateDialog = WDialog.extend({
   statics: {
     TYPE: "stateDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = StateDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: StateDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -10,7 +10,6 @@ const StateDialog = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._setup();
     this._displayDialog();

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -15,10 +15,6 @@ const StateDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -177,24 +177,27 @@ const TeamListDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
     buttons[wX("NEW_TEAM")] = () => {
-      const p = new PromptDialog(window.map);
-      p.setup(wX("CREATE_NEW_TEAM"), wX("NTNAME"), async () => {
-        const newname = p.inputField.value;
-        if (!newname) {
-          alert(wX("NAME_REQ"));
-          return;
-        }
-        try {
-          await newTeamPromise(newname);
-          alert(wX("TEAM_CREATED", newname));
-          await WasabeeMe.waitGet(true); // triggers UIUpdate
-        } catch (e) {
-          console.error(e);
-          alert(e.toString());
-        }
+      const p = new PromptDialog(window.map, {
+        title: wX("CREATE_NEW_TEAM"),
+        label: wX("NTNAME"),
+        callback: async () => {
+          const newname = p.inputField.value;
+          if (!newname) {
+            alert(wX("NAME_REQ"));
+            return;
+          }
+          try {
+            await newTeamPromise(newname);
+            alert(wX("TEAM_CREATED", newname));
+            await WasabeeMe.waitGet(true); // triggers UIUpdate
+          } catch (e) {
+            console.error(e);
+            alert(e.toString());
+          }
+        },
+        current: wX("NEW_TEAM_NAME"),
+        placeholder: wX("AMAZ_TEAM_NAME"),
       });
-      p.current = wX("NEW_TEAM_NAME");
-      p.placeholder = wX("AMAZ_TEAM_NAME");
       p.enable();
     };
 

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -21,8 +21,8 @@ const TeamListDialog = WDialog.extend({
   },
 
   addHooks: async function () {
-    this._me = await WasabeeMe.waitGet(true);
     WDialog.prototype.addHooks.call(this);
+    this._me = await WasabeeMe.waitGet(true);
     window.map.on("wasabeeUIUpdate", this.update, this);
     this._displayDialog();
   },

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -149,8 +149,7 @@ const TeamListDialog = WDialog.extend({
             link.textContent = wX("MANAGE");
             L.DomEvent.on(link, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const mtd = new ManageTeamDialog();
-              mtd.setup(obj);
+              const mtd = new ManageTeamDialog(window.map, { team: obj });
               mtd.enable();
             });
           }

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -14,17 +14,10 @@ import TeamMembershipList from "./teamMembershipList";
 import ConfirmDialog from "./confirmDialog";
 import ManageTeamDialog from "./manageTeamDialog";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const TeamListDialog = WDialog.extend({
   statics: {
     TYPE: "wasabeeButton",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = TeamListDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: TeamListDialog.TYPE });
   },
 
   addHooks: async function () {

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -125,11 +125,10 @@ const TeamListDialog = WDialog.extend({
             link.textContent = wX("LEAVE");
             L.DomEvent.on(link, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const cd = new ConfirmDialog();
-              cd.setup(
-                `Leave ${obj.Name}?`,
-                `If you leave ${obj.Name} you cannot rejoin unless the owner re-adds you.`,
-                async () => {
+              const cd = new ConfirmDialog(window.map, {
+                title: `Leave ${obj.Name}?`,
+                label: `If you leave ${obj.Name} you cannot rejoin unless the owner re-adds you.`,
+                callback: async () => {
                   try {
                     await leaveTeamPromise(obj.ID);
                     await WasabeeMe.waitGet(true);
@@ -141,8 +140,8 @@ const TeamListDialog = WDialog.extend({
                   } catch (e) {
                     console.error(e);
                   }
-                }
-              );
+                },
+              });
               cd.enable();
             });
           } else {

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -49,10 +49,9 @@ const TeamListDialog = WDialog.extend({
           const link = L.DomUtil.create("a", "enl", row);
           link.href = "#";
           link.textContent = value;
-          L.DomEvent.on(link, "click", async (ev) => {
+          L.DomEvent.on(link, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const td = new TeamMembershipList();
-            await td.setup(team.ID);
+            const td = new TeamMembershipList(window.map, { teamID: team.ID });
             td.enable();
           });
         },

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -51,7 +51,7 @@ const TeamListDialog = WDialog.extend({
           link.textContent = value;
           L.DomEvent.on(link, "click", (ev) => {
             L.DomEvent.stop(ev);
-            const td = new TeamMembershipList(window.map, { teamID: team.ID });
+            const td = new TeamMembershipList({ teamID: team.ID });
             td.enable();
           });
         },
@@ -124,7 +124,7 @@ const TeamListDialog = WDialog.extend({
             link.textContent = wX("LEAVE");
             L.DomEvent.on(link, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const cd = new ConfirmDialog(window.map, {
+              const cd = new ConfirmDialog({
                 title: `Leave ${obj.Name}?`,
                 label: `If you leave ${obj.Name} you cannot rejoin unless the owner re-adds you.`,
                 callback: async () => {
@@ -148,7 +148,7 @@ const TeamListDialog = WDialog.extend({
             link.textContent = wX("MANAGE");
             L.DomEvent.on(link, "click", (ev) => {
               L.DomEvent.stop(ev);
-              const mtd = new ManageTeamDialog(window.map, { team: obj });
+              const mtd = new ManageTeamDialog({ team: obj });
               mtd.enable();
             });
           }
@@ -176,7 +176,7 @@ const TeamListDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
     buttons[wX("NEW_TEAM")] = () => {
-      const p = new PromptDialog(window.map, {
+      const p = new PromptDialog({
         title: wX("CREATE_NEW_TEAM"),
         label: wX("NTNAME"),
         callback: async () => {

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -13,10 +13,6 @@ const TeamMembershipList = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayDialog: async function () {
     await this._setup();
     // sometimes we are too quick, try again

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -18,9 +18,11 @@ const TeamMembershipList = WDialog.extend({
     WDialog.prototype.removeHooks.call(this);
   },
 
-  _displayDialog: function () {
+  _displayDialog: async function () {
+    await this._setup();
     // sometimes we are too quick, try again
-    if (!this._team) this._team = window.plugin.wasabee.teams.get(this._teamID);
+    if (!this._team)
+      this._team = window.plugin.wasabee.teams.get(this.options.teamID);
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -41,11 +43,9 @@ const TeamMembershipList = WDialog.extend({
     this._dialog.dialog("option", "buttons", buttons);
   },
 
-  setup: async function (teamID) {
-    this._teamID = teamID;
-
+  _setup: async function () {
     try {
-      this._team = await WasabeeTeam.waitGet(teamID, 2);
+      this._team = await WasabeeTeam.waitGet(this.options.teamID, 2);
     } catch (e) {
       console.error(e);
       alert(e.toString());
@@ -62,7 +62,7 @@ const TeamMembershipList = WDialog.extend({
         value: (agent) => agent.name,
         sort: (a, b) => a.localeCompare(b),
         format: (cell, value, agent) =>
-          cell.appendChild(agent.formatDisplay(this._teamID)),
+          cell.appendChild(agent.formatDisplay(this.options.teamID)),
       },
       {
         name: wX("SQUAD"),

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -8,6 +8,10 @@ const TeamMembershipList = WDialog.extend({
     TYPE: "teamMembershipList",
   },
 
+  options: {
+    // teamID
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -2,17 +2,10 @@ import { WDialog } from "../leafletClasses";
 import Sortable from "../../lib/sortable";
 import WasabeeTeam from "../team";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 
 const TeamMembershipList = WDialog.extend({
   statics: {
     TYPE: "teamMembershipList",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = TeamMembershipList.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: TeamMembershipList.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -9,7 +9,6 @@ const TeamMembershipList = WDialog.extend({
   },
 
   addHooks: function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();
   },

--- a/src/code/dialogs/trawl.js
+++ b/src/code/dialogs/trawl.js
@@ -17,10 +17,6 @@ const TrawlDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-  },
-
   _displayTrawlerDialog: function (tiles) {
     const container = L.DomUtil.create("div", "container");
     const warning = L.DomUtil.create("label", null, container);

--- a/src/code/dialogs/trawl.js
+++ b/src/code/dialogs/trawl.js
@@ -5,17 +5,10 @@ import { blockerAutomark } from "../uiCommands";
 // why trust my own math when someone else has done the work?
 import VLatLon from "../../lib/geodesy-2.2.1/latlon-ellipsoidal-vincenty";
 // import { datums } from "../../lib/geodesy-2.2.1/latlon-ellipsoidal-datum";
-import { postToFirebase } from "../firebaseSupport";
 
 const TrawlDialog = WDialog.extend({
   statics: {
     TYPE: "trawl",
-  },
-
-  initialize: function (map = window.map, options) {
-    WDialog.prototype.initialize.call(this, map, options);
-    this.type = TrawlDialog.TYPE;
-    postToFirebase({ id: "analytics", action: TrawlDialog.TYPE });
   },
 
   // WDialog is a leaflet L.Handler, which takes add/removeHooks

--- a/src/code/dialogs/wasabeeDlist.js
+++ b/src/code/dialogs/wasabeeDlist.js
@@ -11,7 +11,6 @@ const WasabeeDList = WDialog.extend({
   },
 
   addHooks: async function () {
-    if (!this._map) return;
     WDialog.prototype.addHooks.call(this);
     const context = this;
     this._UIUpdateHook = () => {

--- a/src/code/dialogs/wasabeeDlist.js
+++ b/src/code/dialogs/wasabeeDlist.js
@@ -4,17 +4,10 @@ import wX from "../wX";
 import WasabeeMe from "../me";
 import WasabeePortal from "../portal";
 import { getPortalDetails } from "../uiCommands";
-import { postToFirebase } from "../firebaseSupport";
 
 const WasabeeDList = WDialog.extend({
   statics: {
     TYPE: "wasabeeDList",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = WasabeeDList.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: WasabeeDList.TYPE });
   },
 
   addHooks: async function () {

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -87,7 +87,7 @@ const ZoneDialog = WDialog.extend({
       color.href = "#";
       L.DomEvent.on(color, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const zoneSetColorDialog = new ZoneSetColorDialog(window.map, {
+        const zoneSetColorDialog = new ZoneSetColorDialog({
           zone: z,
         });
         zoneSetColorDialog.enable();

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -1,18 +1,11 @@
 import { WDialog } from "../leafletClasses";
 import wX from "../wX";
-import { postToFirebase } from "../firebaseSupport";
 import { getSelectedOperation } from "../selectedOp";
 import ZoneSetColorDialog from "./zoneSetColor";
 
 const ZoneDialog = WDialog.extend({
   statics: {
     TYPE: "zone",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = ZoneDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: ZoneDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -87,8 +87,9 @@ const ZoneDialog = WDialog.extend({
       color.href = "#";
       L.DomEvent.on(color, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const zoneSetColorDialog = new ZoneSetColorDialog();
-        zoneSetColorDialog.setup(z);
+        const zoneSetColorDialog = new ZoneSetColorDialog(window.map, {
+          zone: z,
+        });
         zoneSetColorDialog.enable();
       });
       if (z.id != 1) {

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -12,11 +12,6 @@ const ZoneSetColorDialog = WDialog.extend({
     this._displayDialog();
   },
 
-  removeHooks: function () {
-    WDialog.prototype.removeHooks.call(this);
-    window.map.fire("wasabeeUIUpdate", { reason: "ZoneSetColorDialog" }, false);
-  },
-
   _displayDialog: function () {
     this._dialog = window.dialog({
       title: "Zone color",

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -1,17 +1,10 @@
 import { WDialog } from "../leafletClasses";
-import { postToFirebase } from "../firebaseSupport";
 import { getSelectedOperation } from "../selectedOp";
 import { addToColorList } from "../skin";
 
 const ZoneSetColorDialog = WDialog.extend({
   statics: {
     TYPE: "zoneSetColorDialog",
-  },
-
-  initialize: function (map = window.map, options) {
-    this.type = ZoneSetColorDialog.TYPE;
-    WDialog.prototype.initialize.call(this, map, options);
-    postToFirebase({ id: "analytics", action: ZoneSetColorDialog.TYPE });
   },
 
   addHooks: function () {

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -7,6 +7,10 @@ const ZoneSetColorDialog = WDialog.extend({
     TYPE: "zoneSetColorDialog",
   },
 
+  options: {
+    // zone
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     this._displayDialog();

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -30,14 +30,11 @@ const ZoneSetColorDialog = WDialog.extend({
     });
   },
 
-  setup: function (zone) {
-    this._zone = zone;
-  },
-
   _buildContent: function () {
     const container = L.DomUtil.create("div", "container");
     const desc = L.DomUtil.create("div", "desc", container);
-    desc.textContent = "Set the color of all links in zone " + this._zone.name;
+    desc.textContent =
+      "Set the color of all links in zone " + this.options.zone.name;
 
     const picker = L.DomUtil.create("input", "picker", container);
     picker.type = "color";
@@ -47,7 +44,7 @@ const ZoneSetColorDialog = WDialog.extend({
       L.DomEvent.stop(ev);
       const so = getSelectedOperation();
       for (const l of so.links) {
-        if (l.zone == this._zone.id) l.color = picker.value;
+        if (l.zone == this.options.zone.id) l.color = picker.value;
       }
       so.store();
       addToColorList(picker.value);

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -4,7 +4,7 @@ import { setupLocalStorage, initSelectedOperation } from "./selectedOp";
 import { drawMap, drawAgents } from "./mapDrawing";
 import addButtons from "./addButtons";
 import { setupToolbox } from "./toolbox";
-import { initFirebase } from "./firebaseSupport";
+import { initFirebase, postToFirebase } from "./firebaseSupport";
 import { initWasabeeD } from "./wd";
 import { listenForPortalDetails, sendLocation } from "./uiCommands";
 import { initSkin, changeSkin } from "./skin";
@@ -138,6 +138,10 @@ window.plugin.wasabee.init = () => {
     // load Wasabee-Defense keys if logged in
     window.map.fire("wasabeeDkeys", { reason: "startup" }, false);
   }
+
+  window.map.on("wdialog", (dialog) => {
+    postToFirebase({ id: "analytics", action: dialog.constructor.TYPE });
+  });
 };
 
 // this can be moved to auth dialog, no need to init it for people who never log in

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -37,6 +37,10 @@ export const WTooltip = L.Class.extend({
 });
 
 export const WDialog = L.Handler.extend({
+  statics: {
+    TYPE: "Unextended Wasabee Dialog",
+  },
+
   initialize: function (map = window.map, options) {
     if (this.type === undefined) this.type = "Unextended Wasabee Dialog";
     this._map = map;
@@ -48,6 +52,7 @@ export const WDialog = L.Handler.extend({
     this._dialog = null;
     // look for operation in options, if not set, get it
     // determine large or small screen dialog sizes
+    window.map.fire("wdialog", this);
   },
 
   enable: function () {

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -41,10 +41,8 @@ export const WDialog = L.Handler.extend({
     TYPE: "Unextended Wasabee Dialog",
   },
 
-  initialize: function (map = window.map, options) {
+  initialize: function (options) {
     L.setOptions(this, options);
-    this._map = map;
-    this._container = map._container;
     this._enabled = false;
     this._smallScreen = this._isMobile();
     this._dialog = null;

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -42,11 +42,9 @@ export const WDialog = L.Handler.extend({
   },
 
   initialize: function (map = window.map, options) {
-    if (this.type === undefined) this.type = "Unextended Wasabee Dialog";
+    L.setOptions(this, options);
     this._map = map;
     this._container = map._container;
-    this.options = {};
-    L.Util.extend(this.options, options);
     this._enabled = false;
     this._smallScreen = this._isMobile();
     this._dialog = null;

--- a/src/code/link.js
+++ b/src/code/link.js
@@ -218,7 +218,7 @@ export default class WasabeeLink {
       assignButton.textContent = wX("ASSIGN");
       L.DomEvent.on(assignButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const ad = new AssignDialog(window.map, { target: this });
+        const ad = new AssignDialog({ target: this });
         ad.enable();
       });
     }

--- a/src/code/link.js
+++ b/src/code/link.js
@@ -218,8 +218,7 @@ export default class WasabeeLink {
       assignButton.textContent = wX("ASSIGN");
       L.DomEvent.on(assignButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const ad = new AssignDialog();
-        ad.setup(this, operation);
+        const ad = new AssignDialog(window.map, { target: this });
         ad.enable();
       });
     }

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -140,8 +140,7 @@ export default class WasabeeMarker {
       assignButton.textContent = wX("ASSIGN");
       L.DomEvent.on(assignButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const ad = new AssignDialog();
-        ad.setup(this, operation);
+        const ad = new AssignDialog(window.map, { target: this });
         ad.enable();
         marker.closePopup();
       });

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -209,9 +209,11 @@ export default class WasabeeMarker {
       comment.textContent = this.comment;
       L.DomEvent.on(comment, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const com = new SetCommentDialog();
-        com.setup(this, operation);
-        com.enable();
+        const scd = new SetCommentDialog(window.map, {
+          target: this,
+          operation: operation,
+        });
+        scd.enable();
         marker.closePopup();
       });
     }
@@ -221,9 +223,11 @@ export default class WasabeeMarker {
     cl.href = "#";
     L.DomEvent.on(cl, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const cd = new SetCommentDialog();
-      cd.setup(portal, operation);
-      cd.enable();
+      const scd = new SetCommentDialog(window.map, {
+        target: portal,
+        operation: operation,
+      });
+      scd.enable();
       marker.closePopup();
     });
     if (portal.hardness) {
@@ -237,9 +241,11 @@ export default class WasabeeMarker {
       hl.href = "#";
       L.DomEvent.on(hl, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const cd = new SetCommentDialog();
-        cd.setup(portal, operation);
-        cd.enable();
+        const scd = new SetCommentDialog(window.map, {
+          target: portal,
+          operation: operation,
+        });
+        scd.enable();
         marker.closePopup();
       });
     }

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -196,8 +196,7 @@ export default class WasabeeMarker {
     kind.href = "#";
     L.DomEvent.on(kind, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const ch = new MarkerChangeDialog();
-      ch.setup(this);
+      const ch = new MarkerChangeDialog(window.map, { marker: this });
       ch.enable();
       marker.closePopup();
     });

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -140,7 +140,7 @@ export default class WasabeeMarker {
       assignButton.textContent = wX("ASSIGN");
       L.DomEvent.on(assignButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const ad = new AssignDialog(window.map, { target: this });
+        const ad = new AssignDialog({ target: this });
         ad.enable();
         marker.closePopup();
       });
@@ -149,7 +149,7 @@ export default class WasabeeMarker {
       sendTargetButton.textContent = wX("SEND TARGET");
       L.DomEvent.on(sendTargetButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const std = new SendTargetDialog(window.map, { target: this });
+        const std = new SendTargetDialog({ target: this });
         std.enable();
         marker.closePopup();
       });
@@ -195,7 +195,7 @@ export default class WasabeeMarker {
     kind.href = "#";
     L.DomEvent.on(kind, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const ch = new MarkerChangeDialog(window.map, { marker: this });
+      const ch = new MarkerChangeDialog({ marker: this });
       ch.enable();
       marker.closePopup();
     });
@@ -209,7 +209,7 @@ export default class WasabeeMarker {
       comment.textContent = this.comment;
       L.DomEvent.on(comment, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const scd = new SetCommentDialog(window.map, {
+        const scd = new SetCommentDialog({
           target: this,
           operation: operation,
         });
@@ -223,7 +223,7 @@ export default class WasabeeMarker {
     cl.href = "#";
     L.DomEvent.on(cl, "click", (ev) => {
       L.DomEvent.stop(ev);
-      const scd = new SetCommentDialog(window.map, {
+      const scd = new SetCommentDialog({
         target: portal,
         operation: operation,
       });
@@ -241,7 +241,7 @@ export default class WasabeeMarker {
       hl.href = "#";
       L.DomEvent.on(hl, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const scd = new SetCommentDialog(window.map, {
+        const scd = new SetCommentDialog({
           target: portal,
           operation: operation,
         });

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -149,8 +149,7 @@ export default class WasabeeMarker {
       sendTargetButton.textContent = wX("SEND TARGET");
       L.DomEvent.on(sendTargetButton, "click", (ev) => {
         L.DomEvent.stop(ev);
-        const std = new SendTargetDialog();
-        std.setup(this);
+        const std = new SendTargetDialog(window.map, { target: this });
         std.enable();
         marker.closePopup();
       });

--- a/src/code/uiCommands.js
+++ b/src/code/uiCommands.js
@@ -40,7 +40,7 @@ export function swapPortal(operation, portal) {
   L.DomUtil.create("span", null, pr).textContent = wX("SWAP WITH");
   pr.appendChild(selectedPortal.displayFormat());
   L.DomUtil.create("span", null, pr).textContent = "?";
-  const con = new ConfirmDialog(window.map, {
+  const con = new ConfirmDialog({
     title: wX("SWAP TITLE"),
     label: pr,
     callback: () => {
@@ -54,7 +54,7 @@ export function deletePortal(operation, portal) {
   const pr = L.DomUtil.create("div", null);
   pr.textContent = wX("DELETE ANCHOR PROMPT");
   pr.appendChild(portal.displayFormat());
-  const con = new ConfirmDialog(window.map, {
+  const con = new ConfirmDialog({
     title: wX("DELETE ANCHOR TITLE"),
     label: pr,
     callback: () => {
@@ -68,7 +68,7 @@ export function deleteMarker(operation, marker, portal) {
   const pr = L.DomUtil.create("div", null);
   pr.textContent = wX("DELETE MARKER PROMPT");
   pr.appendChild(portal.displayFormat());
-  const con = new ConfirmDialog(window.map, {
+  const con = new ConfirmDialog({
     title: wX("DELETE MARKER TITLE"),
     label: pr,
     callback: () => {
@@ -79,7 +79,7 @@ export function deleteMarker(operation, marker, portal) {
 }
 
 export function clearAllItems(operation) {
-  const con = new ConfirmDialog(window.map, {
+  const con = new ConfirmDialog({
     title: `Clear: ${operation.name}`,
     label: `Do you want to reset ${operation.name}?`,
     callback: () => {
@@ -91,7 +91,7 @@ export function clearAllItems(operation) {
 }
 
 export function clearAllLinks(operation) {
-  const con = new ConfirmDialog(window.map, {
+  const con = new ConfirmDialog({
     title: `Clear Links: ${operation.name}`,
     label: `Do you want to remove all links from ${operation.name}?`,
     callback: () => {
@@ -103,7 +103,7 @@ export function clearAllLinks(operation) {
 }
 
 export function clearAllMarkers(operation) {
-  const con = new ConfirmDialog(window.map, {
+  const con = new ConfirmDialog({
     title: `Clear Markers: ${operation.name}`,
     label: `Do you want to remove all markers from ${operation.name}?`,
     callback: () => {
@@ -408,7 +408,7 @@ export async function syncOp(opID) {
     if (!localOp.localchanged) {
       remoteOp.store();
     } else {
-      const con = new MergeDialog(window.map, {
+      const con = new MergeDialog({
         opOwn: localOp,
         opRemote: remoteOp,
       });
@@ -418,7 +418,7 @@ export async function syncOp(opID) {
 }
 
 export function deleteLocalOp(opname, opid) {
-  const con = new ConfirmDialog(window.map, {
+  const con = new ConfirmDialog({
     title: wX("REM_LOC_CP", opname),
     label: wX("YESNO_DEL", opname),
     callback: () => {

--- a/src/code/uiCommands.js
+++ b/src/code/uiCommands.js
@@ -34,77 +34,83 @@ export function swapPortal(operation, portal) {
     return;
   }
 
-  const con = new ConfirmDialog();
   const pr = L.DomUtil.create("div", null);
   pr.textContent = wX("SWAP PROMPT");
   pr.appendChild(portal.displayFormat());
   L.DomUtil.create("span", null, pr).textContent = wX("SWAP WITH");
   pr.appendChild(selectedPortal.displayFormat());
   L.DomUtil.create("span", null, pr).textContent = "?";
-  con.setup(wX("SWAP TITLE"), pr, () => {
-    operation.swapPortal(portal, selectedPortal);
+  const con = new ConfirmDialog(window.map, {
+    title: wX("SWAP TITLE"),
+    label: pr,
+    callback: () => {
+      operation.swapPortal(portal, selectedPortal);
+    },
   });
   con.enable();
 }
 
 export function deletePortal(operation, portal) {
-  const con = new ConfirmDialog();
   const pr = L.DomUtil.create("div", null);
   pr.textContent = wX("DELETE ANCHOR PROMPT");
   pr.appendChild(portal.displayFormat());
-  con.setup(wX("DELETE ANCHOR TITLE"), pr, () => {
-    operation.removeAnchor(portal.id);
+  const con = new ConfirmDialog(window.map, {
+    title: wX("DELETE ANCHOR TITLE"),
+    label: pr,
+    callback: () => {
+      operation.removeAnchor(portal.id);
+    },
   });
   con.enable();
 }
 
 export function deleteMarker(operation, marker, portal) {
-  const con = new ConfirmDialog();
   const pr = L.DomUtil.create("div", null);
   pr.textContent = wX("DELETE MARKER PROMPT");
   pr.appendChild(portal.displayFormat());
-  con.setup(wX("DELETE MARKER TITLE"), pr, () => {
-    operation.removeMarker(marker);
+  const con = new ConfirmDialog(window.map, {
+    title: wX("DELETE MARKER TITLE"),
+    label: pr,
+    callback: () => {
+      operation.removeMarker(marker);
+    },
   });
   con.enable();
 }
 
 export function clearAllItems(operation) {
-  const con = new ConfirmDialog();
-  con.setup(
-    `Clear: ${operation.name}`,
-    `Do you want to reset ${operation.name}?`,
-    () => {
+  const con = new ConfirmDialog(window.map, {
+    title: `Clear: ${operation.name}`,
+    label: `Do you want to reset ${operation.name}?`,
+    callback: () => {
       operation.clearAllItems();
       window.map.fire("wasabeeCrosslinks", { reason: "clearAllItems" }, false);
-    }
-  );
+    },
+  });
   con.enable();
 }
 
 export function clearAllLinks(operation) {
-  const con = new ConfirmDialog();
-  con.setup(
-    `Clear Links: ${operation.name}`,
-    `Do you want to remove all links from ${operation.name}?`,
-    () => {
+  const con = new ConfirmDialog(window.map, {
+    title: `Clear Links: ${operation.name}`,
+    label: `Do you want to remove all links from ${operation.name}?`,
+    callback: () => {
       operation.clearAllLinks();
       window.map.fire("wasabeeCrosslinks", { reason: "clearAllItems" }, false);
-    }
-  );
+    },
+  });
   con.enable();
 }
 
 export function clearAllMarkers(operation) {
-  const con = new ConfirmDialog();
-  con.setup(
-    `Clear Markers: ${operation.name}`,
-    `Do you want to remove all markers from ${operation.name}?`,
-    () => {
+  const con = new ConfirmDialog(window.map, {
+    title: `Clear Markers: ${operation.name}`,
+    label: `Do you want to remove all markers from ${operation.name}?`,
+    callback: () => {
       operation.clearAllMarkers();
       window.map.fire("wasabeeCrosslinks", { reason: "clearAllItems" }, false);
-    }
-  );
+    },
+  });
   con.enable();
 }
 
@@ -410,14 +416,17 @@ export async function syncOp(opID) {
 }
 
 export function deleteLocalOp(opname, opid) {
-  const con = new ConfirmDialog(window.map);
-  con.setup(wX("REM_LOC_CP", opname), wX("YESNO_DEL", opname), () => {
-    removeOperation(opid);
-    const newop = changeOpIfNeeded();
-    const mbr = newop.mbr;
-    if (mbr && isFinite(mbr._southWest.lat) && isFinite(mbr._northEast.lat)) {
-      window.map.fitBounds(mbr);
-    }
+  const con = new ConfirmDialog(window.map, {
+    title: wX("REM_LOC_CP", opname),
+    label: wX("YESNO_DEL", opname),
+    callback: () => {
+      removeOperation(opid);
+      const newop = changeOpIfNeeded();
+      const mbr = newop.mbr;
+      if (mbr && isFinite(mbr._southWest.lat) && isFinite(mbr._northEast.lat)) {
+        window.map.fitBounds(mbr);
+      }
+    },
   });
   con.enable();
 }

--- a/src/code/uiCommands.js
+++ b/src/code/uiCommands.js
@@ -408,8 +408,10 @@ export async function syncOp(opID) {
     if (!localOp.localchanged) {
       remoteOp.store();
     } else {
-      const con = new MergeDialog();
-      con.setup(localOp, remoteOp);
+      const con = new MergeDialog(window.map, {
+        opOwn: localOp,
+        opRemote: remoteOp,
+      });
       con.enable();
     }
   }


### PR DESCRIPTION
some refactor using more Leaflet mechanisms and inheritance

 - common `initialize` with analytics moved to WDialog
 - use `.options` instead of `.setup()`
 - remove first parameter `map`

TODO:
 - identify and fix async dialogs