### PR TITLE
introduce wasabee pane on mobile

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
   },
   "globals": {
     "L": "readonly",
-    "PLAYER": "readonly"
+    "PLAYER": "readonly",
+    "android": "readonly"
   }
 }

--- a/src/code/css/panes.css
+++ b/src/code/css/panes.css
@@ -13,11 +13,35 @@
 	display: none;
 }
 
-.wasabee-pane .header {
+.wasabee-pane .wasabee-dialog .header {
+	position: sticky;
+	top: 0;
   font-size: 1.3em;
   line-height: 1.5em;
   font-weight: bold;
   text-align: center;
   color: #ffce00;
-  background-color: #000a;
+  background-color: rgba(8, 48, 78, 0.9);
+	border: 1px solid #20A8B1;
+}
+
+.wasabee-pane .wasabee-dialog .content {
+	overflow-y: hidden;
+}
+
+.wasabee-pane .wasabee-dialog .buttonset {
+  position: sticky;
+  bottom: 0;
+  text-align: right;
+  background-color: rgba(8, 48, 78, 0.9);
+	border: 1px solid #20A8B1;
+}
+
+.wasabee-pane .wasabee-dialog .buttonset button {
+		padding: 2px 4px;
+		margin: 2px;
+    min-width: 40px;
+    color: #FFCE00;
+    border: 1px solid #FFCE00;
+    background-color: rgba(8, 48, 78, 0.9);
 }

--- a/src/code/css/panes.css
+++ b/src/code/css/panes.css
@@ -1,0 +1,14 @@
+.wasabee-pane {
+  background: transparent;
+  border: 0 none;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  position: absolute;
+  overflow: auto;
+}
+
+.wasabee-pane.hidden {
+	display: none;
+}

--- a/src/code/css/panes.css
+++ b/src/code/css/panes.css
@@ -12,3 +12,12 @@
 .wasabee-pane.hidden {
 	display: none;
 }
+
+.wasabee-pane .header {
+  font-size: 1.3em;
+  line-height: 1.5em;
+  font-weight: bold;
+  text-align: center;
+  color: #ffce00;
+  background-color: #000a;
+}

--- a/src/code/css/smallscreen.css
+++ b/src/code/css/smallscreen.css
@@ -1,8 +1,13 @@
-#wasabee-operation-checklist.wasabee-small-screen  .wasabee-table td:first-child input {
+.wasabee-dialog-checklist.wasabee-small-screen .ui-dialog-content,
+.wasabee-dialog-blockerlist.wasabee-small-screen .ui-dialog-content {
+  padding: 0;
+}
+
+.wasabee-dialog-checklist.wasabee-small-screen  .wasabee-table td:first-child input {
   width: 3em;
 }
 
-#wasabee-operation-checklist.wasabee-small-screen  .wasabee-table td:nth-child(3) span {
+.wasabee-dialog-checklist.wasabee-small-screen  .wasabee-table td:nth-child(3) span {
   display: inline-block;
   width: 5em;
   white-space: nowrap;
@@ -11,26 +16,26 @@
   vertical-align: bottom;
 }
 
-#wasabee-operation-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) > div {
+.wasabee-dialog-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) > div {
   display: grid;
   grid-template-columns: auto auto auto;
   grid-column-gap: 2px;
   align-items: center;
 }
 
-#wasabee-operation-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) a.wasabee-portal {
+.wasabee-dialog-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) a.wasabee-portal {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-#wasabee-operation-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) > a.wasabee-portal {
+.wasabee-dialog-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) > a.wasabee-portal {
   display: inline-block;
   vertical-align: bottom;
-  width: calc(100vw - 13em);
+  width: calc(100vw - 13em - 24px);
 }
 
-#wasabee-blockerlist.wasabee-small-screen .wasabee-table a.wasabee-portal {
+.wasabee-dialog-blockerlist.wasabee-small-screen .wasabee-table a.wasabee-portal {
   display: inline-block;
   width: 40vw;
   vertical-align: bottom;

--- a/src/code/css/smallscreen.css
+++ b/src/code/css/smallscreen.css
@@ -1,0 +1,40 @@
+#wasabee-operation-checklist.wasabee-small-screen  .wasabee-table td:first-child input {
+  width: 3em;
+}
+
+#wasabee-operation-checklist.wasabee-small-screen  .wasabee-table td:nth-child(3) span {
+  display: inline-block;
+  width: 5em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+}
+
+#wasabee-operation-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) > div {
+  display: grid;
+  grid-template-columns: auto auto auto;
+  grid-column-gap: 2px;
+  align-items: center;
+}
+
+#wasabee-operation-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) a.wasabee-portal {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+#wasabee-operation-checklist.wasabee-small-screen .wasabee-table td:nth-child(2) > a.wasabee-portal {
+  display: inline-block;
+  vertical-align: bottom;
+  width: calc(100vw - 13em);
+}
+
+#wasabee-blockerlist.wasabee-small-screen .wasabee-table a.wasabee-portal {
+  display: inline-block;
+  width: 40vw;
+  vertical-align: bottom;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/src/code/dialogs/about.js
+++ b/src/code/dialogs/about.js
@@ -46,14 +46,14 @@ const AboutDialog = WDialog.extend({
     // Since the JqueryUI dialog buttons are hard-coded, we have to override them to translate them
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
     // create a JQueryUI dialog, store it in _dialog
     // set closeCallback to report that we are done and free up the memory
     // set id if you want only one instance of this dialog to be displayed at a time
     // enable/disable are inherited from L.Handler via WDialog
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("ABOUT_WASABEE"),
       html: html,
       width: "auto",

--- a/src/code/dialogs/about.js
+++ b/src/code/dialogs/about.js
@@ -57,7 +57,7 @@ const AboutDialog = WDialog.extend({
       title: wX("ABOUT_WASABEE"),
       html: html,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-about",
+      dialogClass: "about",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/about.js
+++ b/src/code/dialogs/about.js
@@ -53,11 +53,12 @@ const AboutDialog = WDialog.extend({
     // set closeCallback to report that we are done and free up the memory
     // set id if you want only one instance of this dialog to be displayed at a time
     // enable/disable are inherited from L.Handler via WDialog
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("ABOUT_WASABEE"),
       html: html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-about",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
@@ -65,8 +66,6 @@ const AboutDialog = WDialog.extend({
       // setting buttons: buttons here would append them -- swap in below
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
-    // swap in our buttons, replacing the defaults
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   // small-screen versions go in _displaySmallDialog

--- a/src/code/dialogs/about.js
+++ b/src/code/dialogs/about.js
@@ -59,10 +59,6 @@ const AboutDialog = WDialog.extend({
       width: "auto",
       dialogClass: "about",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       // setting buttons: buttons here would append them -- swap in below
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -42,18 +42,18 @@ const AgentDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("AGENT_STATS"),
       html: html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-agent",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       // id: window.plugin.wasabee.static.dialogNames.linkList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _displaySmallDialog: function () {

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -48,10 +48,6 @@ const AgentDialog = WDialog.extend({
       width: "auto",
       dialogClass: "agent",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       // id: window.plugin.wasabee.static.dialogNames.linkList,
     });
   },

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -46,7 +46,7 @@ const AgentDialog = WDialog.extend({
       title: wX("AGENT_STATS"),
       html: html,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-agent",
+      dialogClass: "agent",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -39,10 +39,10 @@ const AgentDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("AGENT_STATS"),
       html: html,
       width: "auto",

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -37,10 +37,6 @@ const AssignDialog = WDialog.extend({
       width: "auto",
       dialogClass: "assign",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.assign,
     });
   },
@@ -48,7 +44,6 @@ const AssignDialog = WDialog.extend({
   _setup: async function () {
     const target = this.options.target;
     const operation = getSelectedOperation();
-    this._dialog = null;
     this._targetID = target.ID;
     const divtitle = L.DomUtil.create("div", "desc", this._html);
     const menu = await this._getAgentMenu(target.assignedTo);

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -31,18 +31,18 @@ const AssignDialog = WDialog.extend({
     this._html = L.DomUtil.create("div", "container");
     this._setup();
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: this._name,
       html: this._html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-assign",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.assign,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _setup: async function () {

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -24,14 +24,14 @@ const AssignDialog = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
     // create container then setup asynchronously
     this._html = L.DomUtil.create("div", "container");
     this._setup();
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: this._name,
       html: this._html,
       width: "auto",

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -35,7 +35,7 @@ const AssignDialog = WDialog.extend({
       title: this._name,
       html: this._html,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-assign",
+      dialogClass: "assign",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -189,11 +189,12 @@ const AuthDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("AUTH REQUIRED"),
       html: content,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-auth",
+      buttons: buttons,
       closeCallback: () => {
         if (
           localStorage[
@@ -207,7 +208,6 @@ const AuthDialog = WDialog.extend({
       },
       id: window.plugin.wasabee.static.dialogNames.mustauth,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   // this works in most cases

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -21,6 +21,18 @@ const AuthDialog = WDialog.extend({
     this._displayDialog();
   },
 
+  removeHooks: function () {
+    WDialog.prototype.removeHooks.call(this);
+    if (
+      localStorage[window.plugin.wasabee.static.constants.SEND_LOCATION_KEY] ===
+      "true"
+    )
+      sendLocation();
+    this.randomTip();
+    window.map.fire("wasabeeUIUpdate", { reason: "authDialog" }, false);
+    window.map.fire("wasabeeDkeys", { reason: "authDialog" }, false);
+  },
+
   randomTip: function () {
     const lang = getLanguage();
     if (!window.plugin.wasabee.static.tips[lang]) return;
@@ -195,17 +207,6 @@ const AuthDialog = WDialog.extend({
       width: "auto",
       dialogClass: "auth",
       buttons: buttons,
-      closeCallback: () => {
-        if (
-          localStorage[
-            window.plugin.wasabee.static.constants.SEND_LOCATION_KEY
-          ] === "true"
-        )
-          sendLocation();
-        this.randomTip();
-        window.map.fire("wasabeeUIUpdate", { reason: "authDialog" }, false);
-        window.map.fire("wasabeeDkeys", { reason: "authDialog" }, false);
-      },
       id: window.plugin.wasabee.static.dialogNames.mustauth,
     });
   },

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -193,7 +193,7 @@ const AuthDialog = WDialog.extend({
       title: wX("AUTH REQUIRED"),
       html: content,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-auth",
+      dialogClass: "auth",
       buttons: buttons,
       closeCallback: () => {
         if (

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -124,7 +124,7 @@ const AuthDialog = WDialog.extend({
         try {
           const newme = await WasabeeMe.waitGet(true);
           newme.store();
-          this._dialog.dialog("close");
+          this.closeDialog();
           fullSync();
           postToFirebase({ id: "wasabeeLogin", method: "iOS" });
         } catch (e) {
@@ -170,7 +170,7 @@ const AuthDialog = WDialog.extend({
               await oneTimeToken(ottDialog.inputField.value);
               const newme = await WasabeeMe.waitGet(true);
               newme.store();
-              this._dialog.dialog("close");
+              this.closeDialog();
               fullSync();
               postToFirebase({ id: "wasabeeLogin", method: "One Time Token" });
             } catch (e) {
@@ -186,10 +186,10 @@ const AuthDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("AUTH REQUIRED"),
       html: content,
       width: "auto",
@@ -248,7 +248,7 @@ const AuthDialog = WDialog.extend({
               const r = await SendAccessTokenAsync(responseSelect.access_token);
               const newme = new WasabeeMe(r);
               newme.store();
-              this._dialog.dialog("close");
+              this.closeDialog();
               fullSync();
               postToFirebase({
                 id: "wasabeeLogin",
@@ -257,11 +257,11 @@ const AuthDialog = WDialog.extend({
             } catch (e) {
               alert(wX("AUTH TOKEN REJECTED", e.toString()));
               console.error(e);
-              this._dialog.dialog("close");
+              this.closeDialog();
             }
           });
         } else {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const err = `error from gapiAuth: ${response.error}: ${response.error_subtype}`;
           postToFirebase({ id: "exception", error: err });
           console.log(err);
@@ -273,14 +273,14 @@ const AuthDialog = WDialog.extend({
         const r = await SendAccessTokenAsync(response.access_token);
         const newme = new WasabeeMe(r);
         newme.store();
-        this._dialog.dialog("close");
+        this.closeDialog();
         fullSync();
         postToFirebase({ id: "wasabeeLogin", method: "gsapiAuth" });
       } catch (e) {
         postToFirebase({ id: "exception", error: e.toString() });
         console.error(e);
         alert(e.toString());
-        this._dialog.dialog("close");
+        this.closeDialog();
       }
     });
   },
@@ -296,7 +296,7 @@ const AuthDialog = WDialog.extend({
       },
       async (response) => {
         if (response.error) {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const err = `error from gsapiAuthChoose: ${response.error}: ${response.error_subtype}`;
           alert(err);
           postToFirebase({ id: "exception", error: err });
@@ -306,7 +306,7 @@ const AuthDialog = WDialog.extend({
           const r = await SendAccessTokenAsync(response.access_token);
           const newme = new WasabeeMe(r);
           newme.store();
-          this._dialog.dialog("close");
+          this.closeDialog();
           fullSync();
           postToFirebase({ id: "wasabeeLogin", method: "gsapiAuthChoose" });
         } catch (e) {

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -21,7 +21,7 @@ const AutodrawsDialog = WDialog.extend({
       {
         text: wX("MM"),
         callback: () => {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const mm = new MultimaxDialog();
           mm.enable();
         },
@@ -29,7 +29,7 @@ const AutodrawsDialog = WDialog.extend({
       {
         text: wX("MAX"),
         callback: () => {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const ff = new FanfieldDialog();
           ff.enable();
         },
@@ -37,7 +37,7 @@ const AutodrawsDialog = WDialog.extend({
       {
         text: wX("STARBURST"),
         callback: () => {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const sb = new StarburstDialog();
           sb.enable();
         },
@@ -45,7 +45,7 @@ const AutodrawsDialog = WDialog.extend({
       {
         text: wX("ONION_WAS_TAKEN"),
         callback: () => {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const o = new OnionfieldDialog();
           o.enable();
         },
@@ -53,7 +53,7 @@ const AutodrawsDialog = WDialog.extend({
       {
         text: wX("HG"),
         callback: () => {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const h = new HomogeneousDialog();
           h.enable();
         },
@@ -61,7 +61,7 @@ const AutodrawsDialog = WDialog.extend({
       {
         text: wX("MADRID_WAS_TAKEN"),
         callback: () => {
-          this._dialog.dialog("close");
+          this.closeDialog();
           const m = new MadridDialog();
           m.enable();
         },
@@ -101,10 +101,10 @@ const AutodrawsDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("AUTODRAWS"),
       html: html,
       width: "auto",

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -108,7 +108,7 @@ const AutodrawsDialog = WDialog.extend({
       title: wX("AUTODRAWS"),
       html: html,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-autodraws",
+      dialogClass: "autodraws",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -104,18 +104,18 @@ const AutodrawsDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("AUTODRAWS"),
       html: html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-autodraws",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.autodraws,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _displaySmallDialog: function () {

--- a/src/code/dialogs/autodraws.js
+++ b/src/code/dialogs/autodraws.js
@@ -110,10 +110,6 @@ const AutodrawsDialog = WDialog.extend({
       width: "auto",
       dialogClass: "autodraws",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.autodraws,
     });
   },

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -40,7 +40,7 @@ const BlockerList = WDialog.extend({
     loadFaked(operation);
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
       window.map.fire("wasabeeUIUpdate", { reason: "blockerlist" }, false);
     };
     buttons[wX("AUTOMARK")] = () => {
@@ -66,7 +66,7 @@ const BlockerList = WDialog.extend({
       }
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("KNOWN_BLOCK", operation.name),
       html: this.sortable.table,
       width: "auto",

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -15,6 +15,10 @@ const BlockerList = WDialog.extend({
     TYPE: "blockerList",
   },
 
+  options: {
+    usePane: true,
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.blockerlistUpdate, this);

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -70,7 +70,7 @@ const BlockerList = WDialog.extend({
       title: wX("KNOWN_BLOCK", operation.name),
       html: this.sortable.table,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-blockerlist",
+      dialogClass: "blockerlist",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -72,10 +72,6 @@ const BlockerList = WDialog.extend({
       width: "auto",
       dialogClass: "blockerlist",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.blockerList,
     });
   },

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -84,8 +84,8 @@ const BlockerList = WDialog.extend({
       this.sortable.sortBy,
       this.sortable.sortAsc
     );
-    this._dialog.html(this.sortable.table);
-    this._dialog.dialog("option", "title", wX("KNOWN_BLOCK", operation.name));
+    this.setContent(this.sortable.table);
+    this.setTitle(wX("KNOWN_BLOCK", operation.name));
   },
 
   // because the sortable values depend on the operation, we can't have it created at addHooks unless we want a lot of getSelectedOperations embedded here

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -66,7 +66,7 @@ const BlockerList = WDialog.extend({
       }
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("KNOWN_BLOCK", operation.name),
       html: this.sortable.table,
       width: "auto",

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -105,11 +105,11 @@ const BlockerList = WDialog.extend({
         sort: (a, b) => a.localeCompare(b),
         format: (row, value, blocker) => {
           const p = operation.getPortal(blocker.fromPortalId);
-          row.appendChild(p.displayFormat(this._smallScreen));
+          row.appendChild(p.displayFormat());
         },
       },
       {
-        name: wX("COUNT"),
+        name: this._smallScreen ? "#" : wX("COUNT"),
         value: (blocker) => {
           const c = operation.blockers.filter(
             (b) =>
@@ -128,11 +128,11 @@ const BlockerList = WDialog.extend({
         sort: (a, b) => a.localeCompare(b),
         format: (row, value, blocker) => {
           const p = operation.getPortal(blocker.toPortalId);
-          row.appendChild(p.displayFormat(this._smallScreen));
+          row.appendChild(p.displayFormat());
         },
       },
       {
-        name: wX("COUNT"),
+        name: this._smallScreen ? "#" : wX("COUNT"),
         value: (blocker) => {
           const c = operation.blockers.filter(
             (b) =>

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -21,6 +21,10 @@ const OperationChecklistDialog = WDialog.extend({
     TYPE: "operationChecklist",
   },
 
+  options: {
+    usePane: true,
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.checklistUpdate, this);

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -111,12 +111,11 @@ const OperationChecklistDialog = WDialog.extend({
         sort: (a, b) => a.localeCompare(b),
         format: (cell, value, thing) => {
           if (thing instanceof WasabeeLink) {
-            cell.appendChild(thing.displayFormat(operation, this._smallScreen));
+            cell.appendChild(thing.displayFormat(operation));
+            if (this._smallScreen) cell.colSpan = 2;
           } else {
             cell.appendChild(
-              operation
-                .getPortal(thing.portalId)
-                .displayFormat(this._smallScreen)
+              operation.getPortal(thing.portalId).displayFormat()
             );
           }
         },
@@ -137,7 +136,9 @@ const OperationChecklistDialog = WDialog.extend({
           if (thing.type) L.DomUtil.addClass(span, thing.type);
           span.textContent = value;
 
-          if (thing instanceof WasabeeMarker) {
+          if (thing instanceof WasabeeLink) {
+            if (this._smallScreen) cell.style.display = "none";
+          } else if (thing instanceof WasabeeMarker) {
             L.DomEvent.on(cell, "click", (ev) => {
               L.DomEvent.stop(ev);
               const ch = new MarkerChangeDialog({ marker: thing });
@@ -230,7 +231,7 @@ const OperationChecklistDialog = WDialog.extend({
         smallScreenHide: true,
       },
       {
-        name: "Commands",
+        name: this._smallScreen ? "Cmds" : "Commands",
         value: (obj) => typeof obj,
         format: (cell, value, obj) => {
           if (obj instanceof WasabeeLink) {

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -66,13 +66,13 @@ const OperationChecklistDialog = WDialog.extend({
 
   checklistUpdate: function () {
     const operation = getSelectedOperation();
-    this._dialog.dialog("option", "title", wX("OP_CHECKLIST", operation.name));
+    this.setTitle(wX("OP_CHECKLIST", operation.name));
     this.sortable = this.getListDialogContent(
       operation,
       this.sortable.sortBy,
       this.sortable.sortAsc
     );
-    this._dialog.html(this.sortable.table);
+    this.setContent(this.sortable.table);
   },
 
   getListDialogContent: function (operation, sortBy, sortAsc) {

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -60,10 +60,6 @@ const OperationChecklistDialog = WDialog.extend({
       width: "auto",
       dialogClass: "ui-resizable wasabee-dialog wasabee-dialog-checklist",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._listDialogData;
-      },
       id: window.plugin.wasabee.static.dialogNames.operationChecklist,
     });
   },

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -48,13 +48,13 @@ const OperationChecklistDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("LOAD PORTALS")] = () => {
       loadFaked(operation, true); // force
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("OP_CHECKLIST", operation.name),
       html: this.sortable.table,
       width: "auto",

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -54,18 +54,18 @@ const OperationChecklistDialog = WDialog.extend({
       loadFaked(operation, true); // force
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("OP_CHECKLIST", operation.name),
       html: this.sortable.table,
       width: "auto",
       dialogClass: "ui-resizable wasabee-dialog wasabee-dialog-checklist",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._listDialogData;
       },
       id: window.plugin.wasabee.static.dialogNames.operationChecklist,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   checklistUpdate: function () {

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -48,7 +48,7 @@ const ConfirmDialog = WDialog.extend({
       title: this.options.title,
       html: this._buildContent(),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-confirm",
+      dialogClass: "confirm",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -37,14 +37,14 @@ const ConfirmDialog = WDialog.extend({
     const buttons = {};
     buttons[wX("OK")] = () => {
       if (this.options.callback) this.options.callback();
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CANCEL")] = () => {
       if (this.options.cancelCallback) this.options.cancelCallback();
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: this.options.title,
       html: this._buildContent(),
       width: "auto",

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -50,10 +50,6 @@ const ConfirmDialog = WDialog.extend({
       width: "auto",
       dialogClass: "confirm",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       // id: window.plugin.wasabee.static.dialogNames.XXX
     });
   },

--- a/src/code/dialogs/confirmDialog.js
+++ b/src/code/dialogs/confirmDialog.js
@@ -44,7 +44,7 @@ const ConfirmDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: this.options.title,
       html: this._buildContent(),
       width: "auto",

--- a/src/code/dialogs/defensiveKeysDialog.js
+++ b/src/code/dialogs/defensiveKeysDialog.js
@@ -78,10 +78,10 @@ const DefensiveKeysDialog = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("INPUT_DT_KEY_COUNT"),
       // position: { my: "center top", at: "center center+30" },
       html: this._content,

--- a/src/code/dialogs/defensiveKeysDialog.js
+++ b/src/code/dialogs/defensiveKeysDialog.js
@@ -88,10 +88,6 @@ const DefensiveKeysDialog = WDialog.extend({
       width: "auto",
       dialogClass: "wdkeys",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.wasabeeDKeyButton,
     });
   },

--- a/src/code/dialogs/defensiveKeysDialog.js
+++ b/src/code/dialogs/defensiveKeysDialog.js
@@ -18,7 +18,6 @@ const DefensiveKeysDialog = WDialog.extend({
     };
     window.addHook("portalSelected", this._pch);
 
-    this._buildContent();
     this._displayDialog();
   },
 
@@ -48,23 +47,23 @@ const DefensiveKeysDialog = WDialog.extend({
   },
 
   _buildContent: function () {
-    this._content = L.DomUtil.create("div", "container");
-    this._portal = L.DomUtil.create("div", "portal", this._content);
+    const content = L.DomUtil.create("div", "container");
+    this._portal = L.DomUtil.create("div", "portal", content);
 
-    this._count = L.DomUtil.create("input", null, this._content);
+    this._count = L.DomUtil.create("input", null, content);
     this._count.placeholder = "number of keys";
     this._count.size = 3;
-    this._capID = L.DomUtil.create("input", null, this._content);
+    this._capID = L.DomUtil.create("input", null, content);
     this._capID.placeholder = "Capsule ID";
     this._capID.size = 8;
-    const addDKeyButton = L.DomUtil.create("button", null, this._content);
+    const addDKeyButton = L.DomUtil.create("button", null, content);
     addDKeyButton.textContent = wX("UPDATE_COUNT");
     L.DomEvent.on(addDKeyButton, "click", (ev) => {
       L.DomEvent.stop(ev);
       this._addDKey(); // async, but no need to await it
     });
 
-    const showDKeyButton = L.DomUtil.create("button", null, this._content);
+    const showDKeyButton = L.DomUtil.create("button", null, content);
     showDKeyButton.textContent = wX("D_SHOW_LIST");
     L.DomEvent.on(showDKeyButton, "click", (ev) => {
       L.DomEvent.stop(ev);
@@ -76,6 +75,8 @@ const DefensiveKeysDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
+    const content = this._buildContent();
+
     const buttons = {};
     buttons[wX("OK")] = () => {
       this.closeDialog();
@@ -84,7 +85,7 @@ const DefensiveKeysDialog = WDialog.extend({
     this.createDialog({
       title: wX("INPUT_DT_KEY_COUNT"),
       // position: { my: "center top", at: "center center+30" },
-      html: this._content,
+      html: content,
       width: "auto",
       dialogClass: "wdkeys",
       buttons: buttons,

--- a/src/code/dialogs/defensiveKeysDialog.js
+++ b/src/code/dialogs/defensiveKeysDialog.js
@@ -81,19 +81,19 @@ const DefensiveKeysDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("INPUT_DT_KEY_COUNT"),
       // position: { my: "center top", at: "center center+30" },
       html: this._content,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-wdkeys",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.wasabeeDKeyButton,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _addDKey: async function () {

--- a/src/code/dialogs/defensiveKeysDialog.js
+++ b/src/code/dialogs/defensiveKeysDialog.js
@@ -86,7 +86,7 @@ const DefensiveKeysDialog = WDialog.extend({
       // position: { my: "center top", at: "center center+30" },
       html: this._content,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-wdkeys",
+      dialogClass: "wdkeys",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/exportDialog.js
+++ b/src/code/dialogs/exportDialog.js
@@ -32,10 +32,6 @@ const ExportDialog = WDialog.extend({
       width: "auto",
       dialogClass: "export",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.exportDialog,
     });
   },

--- a/src/code/dialogs/exportDialog.js
+++ b/src/code/dialogs/exportDialog.js
@@ -30,7 +30,7 @@ const ExportDialog = WDialog.extend({
       title: wX("EXPORT") + operation.name,
       html: this._buildContent(operation),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-export",
+      dialogClass: "export",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/exportDialog.js
+++ b/src/code/dialogs/exportDialog.js
@@ -26,18 +26,18 @@ const ExportDialog = WDialog.extend({
       this._bookmarkFormat(operation);
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("EXPORT") + operation.name,
       html: this._buildContent(operation),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-export",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.exportDialog,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _buildContent: function (operation) {

--- a/src/code/dialogs/exportDialog.js
+++ b/src/code/dialogs/exportDialog.js
@@ -17,7 +17,7 @@ const ExportDialog = WDialog.extend({
     const operation = getSelectedOperation();
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("DRAW TOOLS FORMAT")] = () => {
       this._drawToolsFormat(operation);
@@ -26,7 +26,7 @@ const ExportDialog = WDialog.extend({
       this._bookmarkFormat(operation);
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("EXPORT") + operation.name,
       html: this._buildContent(operation),
       width: "auto",

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -122,10 +122,6 @@ const FanfieldDialog = WDialog.extend({
       width: "auto",
       dialogClass: "fanfield",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.fanfield,
     });
   },

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -110,13 +110,13 @@ const FanfieldDialog = WDialog.extend({
     });
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CLEAR LINKS")] = () => {
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("FANFIELD2"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -120,7 +120,7 @@ const FanfieldDialog = WDialog.extend({
       title: wX("FANFIELD2"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-fanfield",
+      dialogClass: "fanfield",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -116,18 +116,18 @@ const FanfieldDialog = WDialog.extend({
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("FANFIELD2"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-fanfield",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.fanfield,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   initialize: function (options) {

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -176,17 +176,17 @@ const HomogeneousDialog = WDialog.extend({
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: "Homogeneous",
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-homogeneous",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   initialize: function (options) {

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -169,14 +169,14 @@ const HomogeneousDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CLEAR LINKS")] = () => {
       this._layerGroup.clearLayers();
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: "Homogeneous",
       html: container,
       width: "auto",

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -180,7 +180,7 @@ const HomogeneousDialog = WDialog.extend({
       title: "Homogeneous",
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-homogeneous",
+      dialogClass: "homogeneous",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -182,10 +182,6 @@ const HomogeneousDialog = WDialog.extend({
       width: "auto",
       dialogClass: "homogeneous",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
     });
   },
 

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -42,13 +42,13 @@ const ImportDialog = WDialog.extend({
     const buttons = {};
     buttons[wX("OK")] = () => {
       this.importTextareaAsOp();
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("GET DT")] = () => {
       this.drawToolsFormat();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("IMP_WAS_OP"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -52,7 +52,7 @@ const ImportDialog = WDialog.extend({
       title: wX("IMP_WAS_OP"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-import",
+      dialogClass: "import",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -48,11 +48,12 @@ const ImportDialog = WDialog.extend({
       this.drawToolsFormat();
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("IMP_WAS_OP"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-import",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
@@ -61,7 +62,6 @@ const ImportDialog = WDialog.extend({
       },
       id: window.plugin.wasabee.static.dialogNames.importDialog,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   drawToolsFormat() {

--- a/src/code/dialogs/importDialog.js
+++ b/src/code/dialogs/importDialog.js
@@ -22,6 +22,13 @@ const ImportDialog = WDialog.extend({
     this._displayDialog();
   },
 
+  removeHooks: function () {
+    WDialog.prototype.removeHooks.call(this);
+
+    window.map.fire("wasabeeUIUpdate", { reason: "import" }, false);
+    window.map.fire("wasabeeCrosslinks", { reason: "import" }, false);
+  },
+
   _displayDialog: function () {
     const container = L.DomUtil.create("div", null);
     container.style.width = "420px";
@@ -54,12 +61,6 @@ const ImportDialog = WDialog.extend({
       width: "auto",
       dialogClass: "import",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-        window.map.fire("wasabeeUIUpdate", { reason: "import" }, false);
-        window.map.fire("wasabeeCrosslinks", { reason: "import" }, false);
-      },
       id: window.plugin.wasabee.static.dialogNames.importDialog,
     });
   },

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -46,10 +46,6 @@ const KeyListPortal = WDialog.extend({
       width: "auto",
       dialogClass: "keylistportal",
       buttons: buttons,
-      closeCallback: () => {
-        delete this._dialog;
-        this.disable();
-      },
       id: window.plugin.wasabee.static.dialogNames.keyListPortal,
     });
   },

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -44,7 +44,7 @@ const KeyListPortal = WDialog.extend({
       title: wX("PORTAL KEY LIST", portal.displayName),
       html: this.getListDialogContent(this.options.portalID),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-keylistportal",
+      dialogClass: "keylistportal",
       buttons: buttons,
       closeCallback: () => {
         delete this._dialog;

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -34,13 +34,13 @@ const KeyListPortal = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
     const op = getSelectedOperation();
     const portal = op.getPortal(this.options.portalID);
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("PORTAL KEY LIST", portal.displayName),
       html: this.getListDialogContent(this.options.portalID),
       width: "auto",

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -40,18 +40,18 @@ const KeyListPortal = WDialog.extend({
     const op = getSelectedOperation();
     const portal = op.getPortal(this.options.portalID);
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("PORTAL KEY LIST", portal.displayName),
       html: this.getListDialogContent(this.options.portalID),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-keylistportal",
+      buttons: buttons,
       closeCallback: () => {
         delete this._dialog;
         this.disable();
       },
       id: window.plugin.wasabee.static.dialogNames.keyListPortal,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   keyListUpdate: function () {

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -56,14 +56,14 @@ const KeyListPortal = WDialog.extend({
     const portal = op.getPortal(this.options.portalID);
     if (portal == null) {
       // needs wX
-      this._dialog("option", "title", "unknown portal");
-      this._dialog.html("selected operation changed");
+      this.setTitle("unknown portal");
+      this.setContent("selected operation changed");
       return;
     }
 
     const table = this.getListDialogContent(this.options.portalID);
-    this._dialog.html(table);
-    this._dialog("option", "title", wX("PORTAL KEY LIST", portal.displayName));
+    this.setContent(table);
+    this.setTitle(wX("PORTAL KEY LIST", portal.displayName));
   },
 
   getSortable: function () {

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -11,6 +11,10 @@ const KeysList = WDialog.extend({
     TYPE: "keysList",
   },
 
+  options: {
+    usePane: true,
+  },
+
   addHooks: async function () {
     WDialog.prototype.addHooks.call(this);
     const operation = getSelectedOperation();

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -54,9 +54,9 @@ const KeysList = WDialog.extend({
     if (WasabeeMe.isLoggedIn()) this._me = await WasabeeMe.waitGet();
     else this._me = null;
 
-    this._dialog.dialog("option", "title", wX("KEY_LIST", operation.name));
+    this.setTitle(wX("KEY_LIST", operation.name));
     const table = this.getListDialogContent(operation).table;
-    this._dialog.html(table);
+    this.setContent(table);
   },
 
   getListDialogContent: function (operation) {

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -36,18 +36,18 @@ const KeysList = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("KEY_LIST2", operation.name),
       html: this.getListDialogContent(operation).table,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-keyslist",
+      buttons: buttons,
       closeCallback: () => {
         delete this._dialog;
         this.disable();
       },
       id: window.plugin.wasabee.static.dialogNames.keysList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   update: async function () {

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -33,10 +33,10 @@ const KeysList = WDialog.extend({
     const operation = getSelectedOperation();
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("KEY_LIST2", operation.name),
       html: this.getListDialogContent(operation).table,
       width: "auto",

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -42,10 +42,6 @@ const KeysList = WDialog.extend({
       width: "auto",
       dialogClass: "keyslist",
       buttons: buttons,
-      closeCallback: () => {
-        delete this._dialog;
-        this.disable();
-      },
       id: window.plugin.wasabee.static.dialogNames.keysList,
     });
   },

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -40,7 +40,7 @@ const KeysList = WDialog.extend({
       title: wX("KEY_LIST2", operation.name),
       html: this.getListDialogContent(operation).table,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-keyslist",
+      dialogClass: "keyslist",
       buttons: buttons,
       closeCallback: () => {
         delete this._dialog;

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -177,18 +177,18 @@ const LinkDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("ADD_LINKS"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-link",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.linkDialogButton,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 });
 

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -181,7 +181,7 @@ const LinkDialog = WDialog.extend({
       title: wX("ADD_LINKS"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-link",
+      dialogClass: "link",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -183,10 +183,6 @@ const LinkDialog = WDialog.extend({
       width: "auto",
       dialogClass: "link",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.linkDialogButton,
     });
   },

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -174,10 +174,10 @@ const LinkDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("ADD_LINKS"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -164,10 +164,10 @@ const LinkListDialog = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: this.options.portal.displayName + wX("LINKS2"),
       html: this._table.table,
       width: "auto",
@@ -237,7 +237,7 @@ const LinkListDialog = WDialog.extend({
       this._table.items = operation.getLinkListFromPortal(this.options.portal);
     } else {
       // the selected operation changed, just bail
-      this._dialog.dialog("close");
+      this.closeDialog();
     }
   },
 });

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -167,18 +167,18 @@ const LinkListDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: this.options.portal.displayName + wX("LINKS2"),
       html: this._table.table,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-linklist",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   deleteLink: function (link) {

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -15,6 +15,7 @@ const LinkListDialog = WDialog.extend({
   },
 
   options: {
+    usePane: true,
     // portal
   },
 

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -171,7 +171,7 @@ const LinkListDialog = WDialog.extend({
       title: this.options.portal.displayName + wX("LINKS2"),
       html: this._table.table,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-linklist",
+      dialogClass: "linklist",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -173,10 +173,6 @@ const LinkListDialog = WDialog.extend({
       width: "auto",
       dialogClass: "linklist",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
   },

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -194,7 +194,7 @@ const MadridDialog = MultimaxDialog.extend({
       title: wX("MADRID_TITLE"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-madrid",
+      dialogClass: "madrid",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -196,10 +196,6 @@ const MadridDialog = MultimaxDialog.extend({
       width: "auto",
       dialogClass: "madrid",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.madrid,
     });
   },

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -190,18 +190,18 @@ const MadridDialog = MultimaxDialog.extend({
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("MADRID_TITLE"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-madrid",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.madrid,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   initialize: function (options) {

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -179,18 +179,18 @@ const MadridDialog = MultimaxDialog.extend({
         ? this.doBalancedMadrid.call(this)
         : this.doMadrid.call(this);
       alert(`Madrid found ${total} layers`);
-      // this._dialog.dialog("close");
+      // this.closeDialog();
     });
 
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CLEAR LINKS")] = () => {
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("MADRID_TITLE"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -332,18 +332,18 @@ const ManageTeamDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("MANAGE_TEAM", this.options.team.Name),
       width: "auto",
       html: container,
       dialogClass: "wasabee-dialog wasabee-dialog-manageteam",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.manageTeam,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 });
 

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -336,7 +336,7 @@ const ManageTeamDialog = WDialog.extend({
       title: wX("MANAGE_TEAM", this.options.team.Name),
       width: "auto",
       html: container,
-      dialogClass: "wasabee-dialog wasabee-dialog-manageteam",
+      dialogClass: "manageteam",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -298,7 +298,7 @@ const ManageTeamDialog = WDialog.extend({
           try {
             await deleteTeamPromise(this.options.team.ID);
             alert(`${this.options.team.Name} removed`);
-            this._dialog.dialog("close");
+            this.closeDialog();
             await WasabeeMe.waitGet(true);
           } catch (e) {
             console.error(e);
@@ -329,10 +329,10 @@ const ManageTeamDialog = WDialog.extend({
     const container = this._dialogContent();
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("MANAGE_TEAM", this.options.team.Name),
       width: "auto",
       html: container,

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -338,10 +338,6 @@ const ManageTeamDialog = WDialog.extend({
       html: container,
       dialogClass: "manageteam",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.manageTeam,
     });
   },

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -151,12 +151,8 @@ const ManageTeamDialog = WDialog.extend({
   update: function () {
     const container = this._dialogContent(); // build the UI
     // this is the correct way to change out a dialog's contents, audit the entire codebase making this change
-    this._dialog.html(container);
-    this._dialog.dialog(
-      "option",
-      "title",
-      wX("MANAGE_TEAM", this.options.team.Name)
-    );
+    this.setContent(container);
+    this.setTitle(wX("MANAGE_TEAM", this.options.team.Name));
   },
 
   _dialogContent: function () {

--- a/src/code/dialogs/markerAddDialog.js
+++ b/src/code/dialogs/markerAddDialog.js
@@ -87,18 +87,18 @@ const MarkerAddDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("ADD MARKER TITLE"),
       html: content,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-markeradd",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.markerButton,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _addMarker: function (selectedType, comment) {

--- a/src/code/dialogs/markerAddDialog.js
+++ b/src/code/dialogs/markerAddDialog.js
@@ -84,10 +84,10 @@ const MarkerAddDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("ADD MARKER TITLE"),
       html: content,
       width: "auto",

--- a/src/code/dialogs/markerAddDialog.js
+++ b/src/code/dialogs/markerAddDialog.js
@@ -93,10 +93,6 @@ const MarkerAddDialog = WDialog.extend({
       width: "auto",
       dialogClass: "markeradd",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.markerButton,
     });
   },

--- a/src/code/dialogs/markerAddDialog.js
+++ b/src/code/dialogs/markerAddDialog.js
@@ -91,7 +91,7 @@ const MarkerAddDialog = WDialog.extend({
       title: wX("ADD MARKER TITLE"),
       html: content,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-markeradd",
+      dialogClass: "markeradd",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -55,7 +55,7 @@ const MarkerChangeDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("SET_MARKER_TYPE_TITLE"),
       html: content,
       width: "auto",

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -49,13 +49,13 @@ const MarkerChangeDialog = WDialog.extend({
           this.options.marker.comment
         );
       }
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CANCEL")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("SET_MARKER_TYPE_TITLE"),
       html: content,
       width: "auto",

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -61,10 +61,6 @@ const MarkerChangeDialog = WDialog.extend({
       width: "auto",
       dialogClass: "markerchange",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.markerButton,
     });
   },

--- a/src/code/dialogs/markerChangeDialog.js
+++ b/src/code/dialogs/markerChangeDialog.js
@@ -59,7 +59,7 @@ const MarkerChangeDialog = WDialog.extend({
       title: wX("SET_MARKER_TYPE_TITLE"),
       html: content,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-markerchange",
+      dialogClass: "markerchange",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -45,10 +45,10 @@ const MarkerList = WDialog.extend({
     };
 
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("MARKER_LIST", operation.name),
       html: this.getListDialogContent(operation).table,
       width: "auto",

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -54,10 +54,6 @@ const MarkerList = WDialog.extend({
       width: "auto",
       dialogClass: "markerlist",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.markerList,
     });
   },

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -62,8 +62,8 @@ const MarkerList = WDialog.extend({
     const operation = getSelectedOperation();
     if (operation.ID != this._opID) console.log("op changed");
     const table = this.getListDialogContent(operation).table;
-    this._dialog.html(table);
-    this._dialog.dialog("option", "title", wX("MARKER_LIST", operation.name));
+    this.setContent(table);
+    this.setTitle(wX("MARKER_LIST", operation.name));
   },
 
   getListDialogContent: function (operation) {

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -52,7 +52,7 @@ const MarkerList = WDialog.extend({
       title: wX("MARKER_LIST", operation.name),
       html: this.getListDialogContent(operation).table,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-markerlist",
+      dialogClass: "markerlist",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -48,18 +48,18 @@ const MarkerList = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("MARKER_LIST", operation.name),
       html: this.getListDialogContent(operation).table,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-markerlist",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.markerList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   markerListUpdate: function () {

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -50,10 +50,6 @@ const MergeDialog = WDialog.extend({
       width: "auto",
       dialogClass: "merge",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
     });
   },
 

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -26,7 +26,7 @@ const MergeDialog = WDialog.extend({
         await this._opRebase.store();
         if (getSelectedOperation().ID == this._opRebase.ID)
           await makeSelectedOperation(this._opRebase.ID);
-        this._dialog.dialog("close");
+        this.closeDialog();
       },
     });
     buttons.push({
@@ -35,16 +35,16 @@ const MergeDialog = WDialog.extend({
         await this.options.opRemote.store();
         if (getSelectedOperation().ID == this.options.opRemote.ID)
           await makeSelectedOperation(this.options.opRemote.ID);
-        this._dialog.dialog("close");
+        this.closeDialog();
       },
     });
     buttons.push({
       text: wX("CANCEL"),
       click: () => {
-        this._dialog.dialog("close");
+        this.closeDialog();
       },
     });
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("MERGE_TITLE"),
       html: this._buildContent(),
       width: "auto",

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -48,7 +48,7 @@ const MergeDialog = WDialog.extend({
       title: wX("MERGE_TITLE"),
       html: this._buildContent(),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-merge",
+      dialogClass: "merge",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -44,7 +44,7 @@ const MergeDialog = WDialog.extend({
         this._dialog.dialog("close");
       },
     });
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("MERGE_TITLE"),
       html: this._buildContent(),
       width: "auto",

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -113,10 +113,6 @@ const MultimaxDialog = WDialog.extend({
       width: "auto",
       dialogClass: "multimax",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.multimaxButton,
     });
   },

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -111,7 +111,7 @@ const MultimaxDialog = WDialog.extend({
       title: wX("MULTI_M_TITLE"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-multimax",
+      dialogClass: "multimax",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -107,18 +107,18 @@ const MultimaxDialog = WDialog.extend({
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("MULTI_M_TITLE"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-multimax",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.multimaxButton,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   initialize: function (options) {

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -96,18 +96,18 @@ const MultimaxDialog = WDialog.extend({
     L.DomEvent.on(button, "click", () => {
       const total = this.doMultimax.call(this);
       alert(`Multimax found ${total} layers`);
-      // this._dialog.dialog("close");
+      // this.closeDialog();
     });
 
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CLEAR LINKS")] = () => {
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("MULTI_M_TITLE"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -72,7 +72,7 @@ const NewopDialog = WDialog.extend({
       title: wX("NEW_OP"),
       html: content,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-newop",
+      dialogClass: "newop",
       buttons: buttons,
       closeCallback: function () {
         noHandler.disable();

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -68,18 +68,18 @@ const NewopDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("NEW_OP"),
       html: content,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-newop",
+      buttons: buttons,
       closeCallback: function () {
         noHandler.disable();
         delete noHandler._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.newopButton,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 });
 

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -15,7 +15,7 @@ const NewopDialog = WDialog.extend({
     this._displayDialog(this);
   },
 
-  _displayDialog: function (noHandler) {
+  _displayDialog: function () {
     const content = L.DomUtil.create("div", null);
     const buttonSet = L.DomUtil.create("div", "buttonset", content);
     const addButton = L.DomUtil.create("button", null, buttonSet);
@@ -25,14 +25,14 @@ const NewopDialog = WDialog.extend({
     importButton.textContent = wX("IMPORT_OP");
     L.DomEvent.on(importButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      noHandler._dialog.dialog("close");
+      this.closeDialog();
       const id = new ImportDialog(null);
       id.enable();
     });
 
     L.DomEvent.on(addButton, "click", (ev) => {
       L.DomEvent.stop(ev);
-      noHandler._dialog.dialog("close");
+      this.closeDialog();
       const addDialog = new PromptDialog({
         title: wX("NEW_OP"),
         label: wX("SET_NEW_OP"),
@@ -74,10 +74,6 @@ const NewopDialog = WDialog.extend({
       width: "auto",
       dialogClass: "newop",
       buttons: buttons,
-      closeCallback: function () {
-        noHandler.disable();
-        delete noHandler._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.newopButton,
     });
   },

--- a/src/code/dialogs/newopDialog.js
+++ b/src/code/dialogs/newopDialog.js
@@ -65,10 +65,10 @@ const NewopDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("NEW_OP"),
       html: content,
       width: "auto",

--- a/src/code/dialogs/onionfield.js
+++ b/src/code/dialogs/onionfield.js
@@ -81,10 +81,6 @@ const OnionfieldDialog = WDialog.extend({
       width: "auto",
       dialogClass: "onion",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
     });
   },
 

--- a/src/code/dialogs/onionfield.js
+++ b/src/code/dialogs/onionfield.js
@@ -79,7 +79,7 @@ const OnionfieldDialog = WDialog.extend({
       title: "Onion/Rose",
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-onion",
+      dialogClass: "onion",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/onionfield.js
+++ b/src/code/dialogs/onionfield.js
@@ -69,13 +69,13 @@ const OnionfieldDialog = WDialog.extend({
     });
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CLEAR LINKS")] = () => {
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: "Onion/Rose",
       html: container,
       width: "auto",

--- a/src/code/dialogs/onionfield.js
+++ b/src/code/dialogs/onionfield.js
@@ -75,17 +75,17 @@ const OnionfieldDialog = WDialog.extend({
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: "Onion/Rose",
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-onion",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   initialize: function (options) {

--- a/src/code/dialogs/onlineAgentList.js
+++ b/src/code/dialogs/onlineAgentList.js
@@ -22,12 +22,12 @@ const OnlineAgentList = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
     this.update();
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: "Online Agents",
       html: this._table.table,
       width: "auto",

--- a/src/code/dialogs/onlineAgentList.js
+++ b/src/code/dialogs/onlineAgentList.js
@@ -31,7 +31,7 @@ const OnlineAgentList = WDialog.extend({
       title: "Online Agents",
       html: this._table.table,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-teamlist",
+      dialogClass: "teamlist",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/onlineAgentList.js
+++ b/src/code/dialogs/onlineAgentList.js
@@ -27,18 +27,18 @@ const OnlineAgentList = WDialog.extend({
 
     this.update();
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: "Online Agents",
       html: this._table.table,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-teamlist",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   update: async function () {

--- a/src/code/dialogs/onlineAgentList.js
+++ b/src/code/dialogs/onlineAgentList.js
@@ -33,10 +33,6 @@ const OnlineAgentList = WDialog.extend({
       width: "auto",
       dialogClass: "teamlist",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
   },

--- a/src/code/dialogs/opPerms.js
+++ b/src/code/dialogs/opPerms.js
@@ -93,10 +93,10 @@ const OpPermList = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("PERMS", operation.name),
       html: this._html,
       height: "auto",

--- a/src/code/dialogs/opPerms.js
+++ b/src/code/dialogs/opPerms.js
@@ -100,7 +100,7 @@ const OpPermList = WDialog.extend({
       title: wX("PERMS", operation.name),
       html: this._html,
       height: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-perms",
+      dialogClass: "perms",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/opPerms.js
+++ b/src/code/dialogs/opPerms.js
@@ -102,10 +102,6 @@ const OpPermList = WDialog.extend({
       height: "auto",
       dialogClass: "perms",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
   },

--- a/src/code/dialogs/opPerms.js
+++ b/src/code/dialogs/opPerms.js
@@ -96,18 +96,18 @@ const OpPermList = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("PERMS", operation.name),
       html: this._html,
       height: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-perms",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   buildTable: function (operation) {

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -45,7 +45,7 @@ const OpSettingDialog = WDialog.extend({
       html: this._content,
       height: "auto",
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-op-settings",
+      dialogClass: "op-settings",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -40,12 +40,13 @@ const OpSettingDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("OP_SETTINGS_TITLE"),
       html: this._content,
       height: "auto",
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-op-settings",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._content;
@@ -53,7 +54,6 @@ const OpSettingDialog = WDialog.extend({
       },
       id: window.plugin.wasabee.static.dialogNames.opSettings,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   update: function () {

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -37,10 +37,10 @@ const OpSettingDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("OP_SETTINGS_TITLE"),
       html: this._content,
       height: "auto",

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -52,9 +52,9 @@ const OpSettingDialog = WDialog.extend({
   },
 
   update: function () {
-    if (this._enabled && this._dialog && this._dialog.html) {
+    if (this._enabled) {
       this.makeContent();
-      this._dialog.html(this._content);
+      this.setContent(this._content);
     }
   },
 

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -47,11 +47,6 @@ const OpSettingDialog = WDialog.extend({
       width: "auto",
       dialogClass: "op-settings",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._content;
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.opSettings,
     });
   },

--- a/src/code/dialogs/opSettings.js
+++ b/src/code/dialogs/opSettings.js
@@ -33,7 +33,7 @@ const OpSettingDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    this.makeContent();
+    const content = this.makeContent();
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -42,7 +42,7 @@ const OpSettingDialog = WDialog.extend({
 
     this.createDialog({
       title: wX("OP_SETTINGS_TITLE"),
-      html: this._content,
+      html: content,
       height: "auto",
       width: "auto",
       dialogClass: "op-settings",
@@ -53,8 +53,8 @@ const OpSettingDialog = WDialog.extend({
 
   update: function () {
     if (this._enabled) {
-      this.makeContent();
-      this.setContent(this._content);
+      const content = this.makeContent();
+      this.setContent(content);
     }
   },
 
@@ -210,7 +210,7 @@ const OpSettingDialog = WDialog.extend({
       await makeSelectedOperation(newop.ID);
     });
 
-    this._content = content;
+    return content;
   },
 });
 

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -44,12 +44,13 @@ const OpsDialog = WDialog.extend({
       this.update();
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("OPERATIONS"),
       html: this._content,
       height: "auto",
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-ops",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._content;
@@ -57,7 +58,6 @@ const OpsDialog = WDialog.extend({
       },
       id: window.plugin.wasabee.static.dialogNames.opsList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   update: async function () {

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -21,6 +21,10 @@ const OpsDialog = WDialog.extend({
     TYPE: "opsDialog",
   },
 
+  options: {
+    usePane: true,
+  },
+
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.update, this);

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -49,7 +49,7 @@ const OpsDialog = WDialog.extend({
       html: this._content,
       height: "auto",
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-ops",
+      dialogClass: "ops",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -37,14 +37,14 @@ const OpsDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons["Unhide all OPs"] = () => {
       resetHiddenOps();
       this.update();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("OPERATIONS"),
       html: this._content,
       height: "auto",

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -51,11 +51,6 @@ const OpsDialog = WDialog.extend({
       width: "auto",
       dialogClass: "ops",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._content;
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.opsList,
     });
   },

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -37,7 +37,7 @@ const OpsDialog = WDialog.extend({
   },
 
   _displayDialog: async function () {
-    await this.makeContent(getSelectedOperation());
+    const content = await this.makeContent(getSelectedOperation());
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -50,7 +50,7 @@ const OpsDialog = WDialog.extend({
 
     this.createDialog({
       title: wX("OPERATIONS"),
-      html: this._content,
+      html: content,
       height: "auto",
       width: "auto",
       dialogClass: "ops",
@@ -61,8 +61,8 @@ const OpsDialog = WDialog.extend({
 
   update: async function () {
     if (this._enabled) {
-      await this.makeContent(getSelectedOperation());
-      this.setContent(this._content);
+      const content = await this.makeContent(getSelectedOperation());
+      this.setContent(content);
     }
   },
 
@@ -259,7 +259,7 @@ const OpsDialog = WDialog.extend({
       }
     }
 
-    this._content = container;
+    return container;
   },
 });
 

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -56,9 +56,9 @@ const OpsDialog = WDialog.extend({
   },
 
   update: async function () {
-    if (this._enabled && this._dialog && this._dialog.html) {
+    if (this._enabled) {
       await this.makeContent(getSelectedOperation());
-      this._dialog.html(this._content);
+      this.setContent(this._content);
     }
   },
 

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -38,7 +38,7 @@ const PromptDialog = WDialog.extend({
       title: this.options.title,
       html: this._buildContent(),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-prompt",
+      dialogClass: "prompt",
       buttons: buttons,
       closeCallback: () => {
         window.map.fire(

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -27,14 +27,14 @@ const PromptDialog = WDialog.extend({
     const buttons = {};
     buttons[wX("OK")] = () => {
       if (this.options.callback) this.options.callback();
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CANCEL")] = () => {
       if (this.options.cancelCallback) this.options.cancelCallback();
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: this.options.title,
       html: this._buildContent(),
       width: "auto",

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -23,6 +23,11 @@ const PromptDialog = WDialog.extend({
     this._displayDialog();
   },
 
+  removeHooks: function () {
+    WDialog.prototype.removeHooks.call(this);
+    window.map.fire("wasabeeUIUpdate", { reason: "PromptDialogClose" }, false);
+  },
+
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -40,15 +45,6 @@ const PromptDialog = WDialog.extend({
       width: "auto",
       dialogClass: "prompt",
       buttons: buttons,
-      closeCallback: () => {
-        window.map.fire(
-          "wasabeeUIUpdate",
-          { reason: "PromptDialogClose" },
-          false
-        );
-        this.disable();
-        delete this._dialog;
-      },
     });
   },
 

--- a/src/code/dialogs/promptDialog.js
+++ b/src/code/dialogs/promptDialog.js
@@ -34,11 +34,12 @@ const PromptDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: this.options.title,
       html: this._buildContent(),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-prompt",
+      buttons: buttons,
       closeCallback: () => {
         window.map.fire(
           "wasabeeUIUpdate",
@@ -49,7 +50,6 @@ const PromptDialog = WDialog.extend({
         delete this._dialog;
       },
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _buildContent: function () {

--- a/src/code/dialogs/saveLinks.js
+++ b/src/code/dialogs/saveLinks.js
@@ -69,7 +69,7 @@ const SaveLinksDialog = WDialog.extend({
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = window.dialog({
+    this.createDialog({
       title: wX("SAVELINKS TITLE"),
       html: container,
       width: "auto",
@@ -78,9 +78,9 @@ const SaveLinksDialog = WDialog.extend({
         this.disable();
         delete this._dialog;
       },
+      buttons: buttons,
       id: window.plugin.wasabee.static.dialogNames.savelinks,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   initialize: function (options) {

--- a/src/code/dialogs/saveLinks.js
+++ b/src/code/dialogs/saveLinks.js
@@ -73,7 +73,7 @@ const SaveLinksDialog = WDialog.extend({
       title: wX("SAVELINKS TITLE"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-savelinks",
+      dialogClass: "savelinks",
       closeCallback: () => {
         this.disable();
         delete this._dialog;

--- a/src/code/dialogs/saveLinks.js
+++ b/src/code/dialogs/saveLinks.js
@@ -63,7 +63,7 @@ const SaveLinksDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CLEAR LINKS")] = () => {
       clearAllLinks(getSelectedOperation());

--- a/src/code/dialogs/saveLinks.js
+++ b/src/code/dialogs/saveLinks.js
@@ -74,10 +74,6 @@ const SaveLinksDialog = WDialog.extend({
       html: container,
       width: "auto",
       dialogClass: "savelinks",
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       buttons: buttons,
       id: window.plugin.wasabee.static.dialogNames.savelinks,
     });

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -34,7 +34,7 @@ const SendTargetDialog = WDialog.extend({
       title: wX("SEND TARGET AGENT"),
       html: this._html,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-sendtarget",
+      dialogClass: "sendtarget",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -36,10 +36,6 @@ const SendTargetDialog = WDialog.extend({
       width: "auto",
       dialogClass: "sendtarget",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.assign,
     });
   },

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -24,13 +24,13 @@ const SendTargetDialog = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
     this._html = L.DomUtil.create("div", null);
     this._setup();
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("SEND TARGET AGENT"),
       html: this._html,
       width: "auto",
@@ -97,7 +97,7 @@ const SendTargetDialog = WDialog.extend({
       const portal = operation.getPortal(this.options.target.portalId);
       try {
         await targetPromise(menu.value, portal, this._targettype);
-        this._dialog.dialog("close");
+        this.closeDialog();
         alert(wX("TARGET SENT"));
       } catch (e) {
         console.error(e);

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -30,18 +30,18 @@ const SendTargetDialog = WDialog.extend({
     this._html = L.DomUtil.create("div", null);
     this._setup();
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("SEND TARGET AGENT"),
       html: this._html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-sendtarget",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.assign,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _setup: async function () {

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -56,18 +56,18 @@ export const SetCommentDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: this.dialogTitle,
       html: this._buildHtml(),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-setcomment",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.setComment,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _buildHtml: function () {

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -53,10 +53,10 @@ export const SetCommentDialog = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: this.dialogTitle,
       html: this._buildHtml(),
       width: "auto",

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -62,10 +62,6 @@ export const SetCommentDialog = WDialog.extend({
       width: "auto",
       dialogClass: "setcomment",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.setComment,
     });
   },

--- a/src/code/dialogs/setCommentDialog.js
+++ b/src/code/dialogs/setCommentDialog.js
@@ -60,7 +60,7 @@ export const SetCommentDialog = WDialog.extend({
       title: this.dialogTitle,
       html: this._buildHtml(),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-setcomment",
+      dialogClass: "setcomment",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -254,10 +254,6 @@ const SettingsDialog = WDialog.extend({
       width: "auto",
       dialogClass: "settings",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.settings,
     });
   },

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -209,15 +209,15 @@ const SettingsDialog = WDialog.extend({
         trawlSelect.value;
     });
 
-    if (window.useAndroidPanes()) {
+    if (window.isSmartphone()) {
       const panesTitle = L.DomUtil.create("label", null, container);
       // XXX:  wX
-      panesTitle.textContent = "Use Android Panes (need reload)";
+      panesTitle.textContent = "Use panes (need reload)";
       panesTitle.htmlFor = "wasabee-setting-usepanes";
       const panesCheck = L.DomUtil.create("input", null, container);
       panesCheck.type = "checkbox";
       panesCheck.id = "wasabee-setting-usepanes";
-      const exm = window.plugin.wasabee.static.constants.USE_ANDROID_PANES;
+      const exm = window.plugin.wasabee.static.constants.USE_PANES;
       const ex = localStorage[exm];
       if (ex === "true") panesCheck.checked = true;
       L.DomEvent.on(panesCheck, "change", (ev) => {

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -209,6 +209,23 @@ const SettingsDialog = WDialog.extend({
         trawlSelect.value;
     });
 
+    if (window.useAndroidPanes()) {
+      const panesTitle = L.DomUtil.create("label", null, container);
+      // XXX:  wX
+      panesTitle.textContent = "Use Android Panes (need reload)";
+      panesTitle.htmlFor = "wasabee-setting-usepanes";
+      const panesCheck = L.DomUtil.create("input", null, container);
+      panesCheck.type = "checkbox";
+      panesCheck.id = "wasabee-setting-usepanes";
+      const exm = window.plugin.wasabee.static.constants.USE_ANDROID_PANES;
+      const ex = localStorage[exm];
+      if (ex === "true") panesCheck.checked = true;
+      L.DomEvent.on(panesCheck, "change", (ev) => {
+        L.DomEvent.stop(ev);
+        localStorage[exm] = panesCheck.checked;
+      });
+    }
+
     const skinsButton = L.DomUtil.create("button", null, container);
     skinsButton.textContent = wX("SKINS_BUTTON");
     L.DomEvent.on(skinsButton, "click", (ev) => {

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -33,7 +33,7 @@ const SettingsDialog = WDialog.extend({
   },
 
   update: function () {
-    this._dialog.html(this._getContent());
+    this.setContent(this._getContent());
     // TODO also update the title
   },
 

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -248,18 +248,18 @@ const SettingsDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("SETTINGS"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-settings",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.settings,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   // small-screen versions go in _displaySmallDialog

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -252,7 +252,7 @@ const SettingsDialog = WDialog.extend({
       title: wX("SETTINGS"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-settings",
+      dialogClass: "settings",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -245,10 +245,10 @@ const SettingsDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("SETTINGS"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/skinDialog.js
+++ b/src/code/dialogs/skinDialog.js
@@ -79,7 +79,7 @@ const SkinDialog = WDialog.extend({
       title: wX("SKINS_MANAGE_TITLE"),
       html: content,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-skin",
+      dialogClass: "skin",
       closeCallback: () => {
         this.disable();
         delete this._dialog;

--- a/src/code/dialogs/skinDialog.js
+++ b/src/code/dialogs/skinDialog.js
@@ -75,7 +75,7 @@ const SkinDialog = WDialog.extend({
   _displayDialog: function () {
     const content = this._buildContent();
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("SKINS_MANAGE_TITLE"),
       html: content,
       width: "auto",

--- a/src/code/dialogs/skinDialog.js
+++ b/src/code/dialogs/skinDialog.js
@@ -75,7 +75,7 @@ const SkinDialog = WDialog.extend({
   _displayDialog: function () {
     const content = this._buildContent();
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("SKINS_MANAGE_TITLE"),
       html: content,
       width: "auto",

--- a/src/code/dialogs/skinDialog.js
+++ b/src/code/dialogs/skinDialog.js
@@ -80,10 +80,6 @@ const SkinDialog = WDialog.extend({
       html: content,
       width: "auto",
       dialogClass: "skin",
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.skinDialog,
     });
   },

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -78,10 +78,6 @@ const StarburstDialog = WDialog.extend({
       width: "auto",
       dialogClass: "starburst",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.starburst,
     });
   },

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -76,7 +76,7 @@ const StarburstDialog = WDialog.extend({
       title: wX("STARBURST TITLE"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-starburst",
+      dialogClass: "starburst",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -66,13 +66,13 @@ const StarburstDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("CLOSE")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("CLEAR LINKS")] = () => {
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("STARBURST TITLE"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -72,18 +72,18 @@ const StarburstDialog = WDialog.extend({
       clearAllLinks(getSelectedOperation());
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("STARBURST TITLE"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-starburst",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.starburst,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   initialize: function (options) {

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -16,7 +16,6 @@ const StateDialog = WDialog.extend({
 
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
-    this._setup();
     this._displayDialog();
   },
 

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -23,13 +23,13 @@ const StateDialog = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
     // for this._name and this._html
     this._buildContent();
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: this._name,
       html: this._html,
       width: "auto",

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -29,18 +29,18 @@ const StateDialog = WDialog.extend({
     // for this._name and this._html
     this._buildContent();
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: this._name,
       html: this._html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-state",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.state,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _buildContent: function () {

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -33,7 +33,7 @@ const StateDialog = WDialog.extend({
       title: this._name,
       html: this._html,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-state",
+      dialogClass: "state",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/stateDialog.js
+++ b/src/code/dialogs/stateDialog.js
@@ -35,10 +35,6 @@ const StateDialog = WDialog.extend({
       width: "auto",
       dialogClass: "state",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.state,
     });
   },

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -206,10 +206,6 @@ const TeamListDialog = WDialog.extend({
       width: "auto",
       dialogClass: "wasabee",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.wasabeeButton,
     });
   },

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -35,7 +35,7 @@ const TeamListDialog = WDialog.extend({
   update: async function () {
     if (!this._enabled) return;
     this._me = await WasabeeMe.waitGet();
-    this._dialog.html(this._buildContent());
+    this.setContent(this._buildContent());
   },
 
   _buildContent: function () {

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -173,7 +173,7 @@ const TeamListDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
     buttons[wX("NEW_TEAM")] = () => {
       const p = new PromptDialog({
@@ -200,7 +200,7 @@ const TeamListDialog = WDialog.extend({
       p.enable();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("CUR_USER_INFO"),
       html: this._buildContent(),
       width: "auto",

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -204,7 +204,7 @@ const TeamListDialog = WDialog.extend({
       title: wX("CUR_USER_INFO"),
       html: this._buildContent(),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-wasabee",
+      dialogClass: "wasabee",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/teamListDialog.js
+++ b/src/code/dialogs/teamListDialog.js
@@ -200,18 +200,18 @@ const TeamListDialog = WDialog.extend({
       p.enable();
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("CUR_USER_INFO"),
       html: this._buildContent(),
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-wasabee",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.wasabeeButton,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   toggleTeam: async function (teamID, currentState) {

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -35,7 +35,7 @@ const TeamMembershipList = WDialog.extend({
       title: team.name,
       html: table.table,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-teamlist",
+      dialogClass: "teamlist",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -31,18 +31,18 @@ const TeamMembershipList = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: team.name,
       html: table.table,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-teamlist",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _setupTable: function () {

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -37,10 +37,6 @@ const TeamMembershipList = WDialog.extend({
       width: "auto",
       dialogClass: "teamlist",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.linkList,
     });
   },

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -28,10 +28,10 @@ const TeamMembershipList = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: team.name,
       html: table.table,
       width: "auto",

--- a/src/code/dialogs/trawl.js
+++ b/src/code/dialogs/trawl.js
@@ -48,10 +48,10 @@ const TrawlDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._trawlerDialog.dialog("close");
+      this.closeDialog("close");
     };
 
-    this._trawlerDialog = this.createDialog({
+    this.createDialog({
       title: wX("TRAWL TITLE"),
       html: container,
       width: "auto",
@@ -61,7 +61,7 @@ const TrawlDialog = WDialog.extend({
         if (window.plugin.wasabee.tileTrawlQueue)
           delete window.plugin.wasabee.tileTrawlQueue;
         this.disable();
-        delete this._trawlerDialog;
+        delete this._dialog;
       },
       // id: window.plugin.wasabee.static.dialogNames.trawl
     });
@@ -105,8 +105,8 @@ const TrawlDialog = WDialog.extend({
       const points = this._getTrawlPoints();
       this._pointTileDataRequest(points, 13);
       const tiles = window.plugin.wasabee.tileTrawlQueue.size;
+      this.closeDialog();
       this._displayTrawlerDialog(tiles);
-      this._dialog.dialog("close");
     });
 
     const crazyWarning = L.DomUtil.create("h4", null, container);
@@ -119,15 +119,15 @@ const TrawlDialog = WDialog.extend({
       if (clearMarkers.checked == true) this._clearMarkers();
       const points = this._getTrawlPoints();
       this._bulkLoad(points, 14);
-      this._dialog.dialog("close");
+      this.closeDialog();
     });
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("TRAWL TITLE"),
       html: container,
       width: "auto",

--- a/src/code/dialogs/trawl.js
+++ b/src/code/dialogs/trawl.js
@@ -17,6 +17,13 @@ const TrawlDialog = WDialog.extend({
     this._displayDialog();
   },
 
+  removeHooks: function () {
+    WDialog.prototype.removeHooks.call(this);
+
+    if (window.plugin.wasabee.tileTrawlQueue)
+      delete window.plugin.wasabee.tileTrawlQueue;
+  },
+
   _displayTrawlerDialog: function (tiles) {
     const container = L.DomUtil.create("div", "container");
     const warning = L.DomUtil.create("label", null, container);
@@ -57,12 +64,6 @@ const TrawlDialog = WDialog.extend({
       width: "auto",
       dialogClass: "trawl",
       buttons: buttons,
-      closeCallback: () => {
-        if (window.plugin.wasabee.tileTrawlQueue)
-          delete window.plugin.wasabee.tileTrawlQueue;
-        this.disable();
-        delete this._dialog;
-      },
       // id: window.plugin.wasabee.static.dialogNames.trawl
     });
   },
@@ -133,10 +134,6 @@ const TrawlDialog = WDialog.extend({
       width: "auto",
       dialogClass: "trawl",
       buttons: buttons,
-      closeCallback: () => {
-        // this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.trawl,
     });
   },

--- a/src/code/dialogs/trawl.js
+++ b/src/code/dialogs/trawl.js
@@ -51,11 +51,12 @@ const TrawlDialog = WDialog.extend({
       this._trawlerDialog.dialog("close");
     };
 
-    this._trawlerDialog = window.dialog({
+    this._trawlerDialog = this.createDialog({
       title: wX("TRAWL TITLE"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-trawl",
+      buttons: buttons,
       closeCallback: () => {
         if (window.plugin.wasabee.tileTrawlQueue)
           delete window.plugin.wasabee.tileTrawlQueue;
@@ -64,7 +65,6 @@ const TrawlDialog = WDialog.extend({
       },
       // id: window.plugin.wasabee.static.dialogNames.trawl
     });
-    this._trawlerDialog.dialog("option", "buttons", buttons);
   },
 
   _updateTrawlerDialog: function (tiles) {
@@ -127,18 +127,18 @@ const TrawlDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("TRAWL TITLE"),
       html: container,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-trawl",
+      buttons: buttons,
       closeCallback: () => {
         // this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.trawl,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _getTrawlPoints: function () {

--- a/src/code/dialogs/trawl.js
+++ b/src/code/dialogs/trawl.js
@@ -55,7 +55,7 @@ const TrawlDialog = WDialog.extend({
       title: wX("TRAWL TITLE"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-trawl",
+      dialogClass: "trawl",
       buttons: buttons,
       closeCallback: () => {
         if (window.plugin.wasabee.tileTrawlQueue)
@@ -131,7 +131,7 @@ const TrawlDialog = WDialog.extend({
       title: wX("TRAWL TITLE"),
       html: container,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-trawl",
+      dialogClass: "trawl",
       buttons: buttons,
       closeCallback: () => {
         // this.disable();

--- a/src/code/dialogs/wasabeeDlist.js
+++ b/src/code/dialogs/wasabeeDlist.js
@@ -37,18 +37,18 @@ const WasabeeDList = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: wX("WASABEE_D_LIST"),
       html: this.getListDialogContent().table,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-wasabeedlist",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.wasabeeDList,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   getListDialogContent: function () {

--- a/src/code/dialogs/wasabeeDlist.js
+++ b/src/code/dialogs/wasabeeDlist.js
@@ -41,7 +41,7 @@ const WasabeeDList = WDialog.extend({
       title: wX("WASABEE_D_LIST"),
       html: this.getListDialogContent().table,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-wasabeedlist",
+      dialogClass: "wasabeedlist",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/wasabeeDlist.js
+++ b/src/code/dialogs/wasabeeDlist.js
@@ -28,7 +28,7 @@ const WasabeeDList = WDialog.extend({
 
   update: function () {
     const table = this.getListDialogContent().table;
-    this._dialog.html(table);
+    this.setContent(table);
   },
 
   _displayDialog: function () {

--- a/src/code/dialogs/wasabeeDlist.js
+++ b/src/code/dialogs/wasabeeDlist.js
@@ -34,10 +34,10 @@ const WasabeeDList = WDialog.extend({
   _displayDialog: function () {
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: wX("WASABEE_D_LIST"),
       html: this.getListDialogContent().table,
       width: "auto",

--- a/src/code/dialogs/wasabeeDlist.js
+++ b/src/code/dialogs/wasabeeDlist.js
@@ -43,10 +43,6 @@ const WasabeeDList = WDialog.extend({
       width: "auto",
       dialogClass: "wasabeedlist",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.wasabeeDList,
     });
   },

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -37,18 +37,18 @@ const ZoneDialog = WDialog.extend({
       this._dialog.dialog("close");
     };
 
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: "Zones",
       html: html,
       width: "auto",
       dialogClass: "wasabee-dialog wasabee-dialog-zone",
+      buttons: buttons,
       closeCallback: () => {
         this.disable();
         delete this._dialog;
       },
       id: window.plugin.wasabee.static.dialogNames.zone,
     });
-    this._dialog.dialog("option", "buttons", buttons);
   },
 
   _displaySmallDialog: function () {

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -34,10 +34,10 @@ const ZoneDialog = WDialog.extend({
 
     const buttons = {};
     buttons[wX("OK")] = () => {
-      this._dialog.dialog("close");
+      this.closeDialog();
     };
 
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: "Zones",
       html: html,
       width: "auto",

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -43,10 +43,6 @@ const ZoneDialog = WDialog.extend({
       width: "auto",
       dialogClass: "zone",
       buttons: buttons,
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
       id: window.plugin.wasabee.static.dialogNames.zone,
     });
   },

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -41,7 +41,7 @@ const ZoneDialog = WDialog.extend({
       title: "Zones",
       html: html,
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-zone",
+      dialogClass: "zone",
       buttons: buttons,
       closeCallback: () => {
         this.disable();

--- a/src/code/dialogs/zoneDialog.js
+++ b/src/code/dialogs/zoneDialog.js
@@ -26,7 +26,7 @@ const ZoneDialog = WDialog.extend({
 
   update: function () {
     const h = this.buildList();
-    this._dialog.html(h);
+    this.setContent(h);
   },
 
   _displayDialog: function () {

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -21,7 +21,7 @@ const ZoneSetColorDialog = WDialog.extend({
       title: "Zone color",
       html: this._buildContent(),
       width: "auto",
-      dialogClass: "wasabee-dialog wasabee-dialog-zone-color",
+      dialogClass: "zone-color",
       closeCallback: () => {
         this.disable();
         delete this._dialog;

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -17,7 +17,7 @@ const ZoneSetColorDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    this._dialog = window.dialog({
+    this._dialog = this.createDialog({
       title: "Zone color",
       html: this._buildContent(),
       width: "auto",

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -22,10 +22,6 @@ const ZoneSetColorDialog = WDialog.extend({
       html: this._buildContent(),
       width: "auto",
       dialogClass: "zone-color",
-      closeCallback: () => {
-        this.disable();
-        delete this._dialog;
-      },
     });
   },
 

--- a/src/code/dialogs/zoneSetColor.js
+++ b/src/code/dialogs/zoneSetColor.js
@@ -17,7 +17,7 @@ const ZoneSetColorDialog = WDialog.extend({
   },
 
   _displayDialog: function () {
-    this._dialog = this.createDialog({
+    this.createDialog({
       title: "Zone color",
       html: this._buildContent(),
       width: "auto",

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -9,6 +9,7 @@ import { initWasabeeD } from "./wd";
 import { listenForPortalDetails, sendLocation } from "./uiCommands";
 import { initSkin, changeSkin } from "./skin";
 import { WPane } from "./leafletClasses";
+import OperationChecklist from "./dialogs/checklist";
 import WasabeeMe from "./me";
 import { openDB } from "idb";
 const Wasabee = window.plugin.wasabee;
@@ -86,7 +87,11 @@ window.plugin.wasabee.init = async () => {
   // Android panes
   const usePanes = localStorage[Wasabee.static.constants.USE_PANES] === "true";
   if (window.isSmartphone() && usePanes) {
-    new WPane();
+    new WPane({
+      paneId: "wasabee",
+      paneName: "Wasabee",
+      default: () => new OperationChecklist(),
+    });
   }
 
   // hooks called when layers are enabled/disabled

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -87,6 +87,7 @@ window.plugin.wasabee.init = async () => {
   // Android panes
   const usePanes = localStorage[Wasabee.static.constants.USE_PANES] === "true";
   if (window.isSmartphone() && usePanes) {
+    /* eslint-disable no-new */
     new WPane({
       paneId: "wasabee",
       paneName: "Wasabee",

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -8,6 +8,7 @@ import { initFirebase, postToFirebase } from "./firebaseSupport";
 import { initWasabeeD } from "./wd";
 import { listenForPortalDetails, sendLocation } from "./uiCommands";
 import { initSkin, changeSkin } from "./skin";
+import { WPane } from "./leafletClasses";
 import WasabeeMe from "./me";
 import { openDB } from "idb";
 const Wasabee = window.plugin.wasabee;
@@ -81,6 +82,13 @@ window.plugin.wasabee.init = async () => {
     window.map.fire("wasabeeUIUpdate", { reason: "resume" }, false);
     sendLocation();
   });
+
+  // Android panes
+  const usePanes =
+    localStorage[Wasabee.static.constants.USE_ANDROID_PANES] === "true";
+  if (window.useAndroidPanes() && usePanes) {
+    new WPane();
+  }
 
   // hooks called when layers are enabled/disabled
   window.map.on("layeradd", (obj) => {

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -84,9 +84,8 @@ window.plugin.wasabee.init = async () => {
   });
 
   // Android panes
-  const usePanes =
-    localStorage[Wasabee.static.constants.USE_ANDROID_PANES] === "true";
-  if (window.useAndroidPanes() && usePanes) {
+  const usePanes = localStorage[Wasabee.static.constants.USE_PANES] === "true";
+  if (window.isSmartphone() && usePanes) {
     new WPane();
   }
 

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -55,6 +55,12 @@ export const WDialog = L.Handler.extend({
   createDialog: function (options) {
     options.dialogClass =
       "wasabee-dialog wasabee-dialog-" + options.dialogClass;
+    if (!options.closeCallback) {
+      options.closeCallback = () => {
+        this.disable();
+        delete this._dialog;
+      };
+    }
     this._dialog = window.dialog(options);
     // swap in our buttons, replacing the defaults
     if (options.buttons)

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -41,6 +41,7 @@ export const WPane = L.Handler.extend({
   options: {
     paneId: "wasabee",
     paneName: "Wasabee",
+    default: null,
   },
 
   initialize: function (options) {
@@ -72,6 +73,10 @@ export const WPane = L.Handler.extend({
 
   addHooks: function () {
     this._container.classList.remove("hidden");
+    if (!this._dialog && this.options.default) {
+      const defaultDialog = this.options.default();
+      defaultDialog.enable();
+    }
   },
 
   removeHooks: function () {
@@ -136,7 +141,6 @@ export const WDialog = L.Handler.extend({
         pane: this.options.paneId,
         dialog: this,
       });
-      /// XXX butons/title etc
     } else {
       if (!options.closeCallback) {
         options.closeCallback = () => {

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -61,6 +61,7 @@ export const WPane = L.Handler.extend({
       if (this._dialog) this._dialog.closeDialog();
       this._dialog = data.dialog;
       this._container.textContent = "";
+      this._container.appendChild(this._dialog._header);
       this._container.appendChild(this._dialog._container);
       window.show(data.pane);
     });
@@ -101,9 +102,12 @@ export const WDialog = L.Handler.extend({
   removeHooks: function () {},
 
   createDialog: function (options) {
+    this.options.title = options.title;
     options.dialogClass =
       "wasabee-dialog wasabee-dialog-" + options.dialogClass;
     if (this.options.usePane) {
+      this._header = L.DomUtil.create("div", "header");
+      if (options.title) this._header.textContent = options.title;
       this._container = L.DomUtil.create("div", options.dialogClass);
       if (options.id) this._container.id = options.id;
       if (options.html) this._container.appendChild(options.html);
@@ -128,6 +132,7 @@ export const WDialog = L.Handler.extend({
 
   setTitle: function (title) {
     if (this._dialog) this._dialog.dialog("option", "title", title);
+    else if (this._header) this._header.textContent = title;
   },
 
   setContent: function (content) {

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -113,6 +113,7 @@ export const WDialog = L.Handler.extend({
     this.options.title = options.title;
     options.dialogClass =
       "wasabee-dialog wasabee-dialog-" + options.dialogClass;
+    if (this._smallScreen) options.dialogClass += " wasabee-small-screen";
     if (this.options.usePane) {
       this._container = L.DomUtil.create("div", options.dialogClass);
       if (options.id) this._container.id = options.id;

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -52,6 +52,13 @@ export const WDialog = L.Handler.extend({
 
   removeHooks: function () {},
 
+  createDialog: function (options) {
+    const dialog = window.dialog(options);
+    // swap in our buttons, replacing the defaults
+    if (options.buttons) dialog.dialog("option", "buttons", options.buttons);
+    return dialog;
+  },
+
   _isMobile: function () {
     // return true;
     // XXX this is a cheap hack -- determine a better check

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -53,6 +53,8 @@ export const WDialog = L.Handler.extend({
   removeHooks: function () {},
 
   createDialog: function (options) {
+    options.dialogClass =
+      "wasabee-dialog wasabee-dialog-" + options.dialogClass;
     const dialog = window.dialog(options);
     // swap in our buttons, replacing the defaults
     if (options.buttons) dialog.dialog("option", "buttons", options.buttons);

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -45,7 +45,8 @@ export const WPane = L.Handler.extend({
 
   initialize: function (options) {
     L.setOptions(this, options);
-    android.addPane(this.options.paneId, this.options.paneName);
+    if (window.useAndroidPanes())
+      android.addPane(this.options.paneId, this.options.paneName);
     window.addHook("paneChanged", (pane) => {
       if (pane === this.options.paneId) this.enable();
       else this.disable();
@@ -91,9 +92,8 @@ export const WDialog = L.Handler.extend({
     window.map.fire("wdialog", this);
     this.options.usePane =
       this.options.usePane &&
-      window.useAndroidPanes() &&
-      localStorage[window.plugin.wasabee.static.constants.USE_ANDROID_PANES] ===
-        "true";
+      window.isSmartphone() &&
+      localStorage[window.plugin.wasabee.static.constants.USE_PANES] === "true";
   },
 
   addHooks: function () {},

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -55,10 +55,18 @@ export const WDialog = L.Handler.extend({
   createDialog: function (options) {
     options.dialogClass =
       "wasabee-dialog wasabee-dialog-" + options.dialogClass;
-    const dialog = window.dialog(options);
+    this._dialog = window.dialog(options);
     // swap in our buttons, replacing the defaults
-    if (options.buttons) dialog.dialog("option", "buttons", options.buttons);
-    return dialog;
+    if (options.buttons)
+      this._dialog.dialog("option", "buttons", options.buttons);
+    return this._dialog;
+  },
+
+  closeDialog: function () {
+    if (this._dialog) {
+      this._dialog.dialog("close");
+      delete this._dialog;
+    }
   },
 
   _isMobile: function () {

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -68,6 +68,14 @@ export const WDialog = L.Handler.extend({
     return this._dialog;
   },
 
+  setTitle: function (title) {
+    if (this._dialog) this._dialog.dialog("option", "title", title);
+  },
+
+  setContent: function (content) {
+    if (this._dialog) this._dialog.html(content);
+  },
+
   closeDialog: function () {
     if (this._dialog) {
       this._dialog.dialog("close");

--- a/src/code/static.js
+++ b/src/code/static.js
@@ -7,6 +7,7 @@ W.static = {
     autodraws: require("./css/autodraws.css"),
     toolbar: require("./css/toolbar.css"),
     panes: require("./css/panes.css"),
+    smallScreen: require("./css/smallscreen.css"),
     // fix for dialogs on mobile from iitc dev version
     // to remove on >IITC-0.30.1
     iitcfix: require("./css/iitcfix.css"),

--- a/src/code/static.js
+++ b/src/code/static.js
@@ -58,7 +58,7 @@ W.static = {
     LAST_MARKER_KEY: "wasabee-last-marker-type",
     AUTO_LOAD_FAKED: "wasabee-autoload-faked",
     TRAWL_SKIP_STEPS: "wasabee-trawl-skip",
-    USE_ANDROID_PANES: "wasabee-use-android-panes",
+    USE_PANES: "wasabee-use-panes",
     OAUTH_CLIENT_ID:
       "269534461245-jbnes60ebd7u0b8naba19h4vqm7ji219.apps.googleusercontent.com",
     SERVER_BASE_KEY: "wasabee-server",

--- a/src/code/static.js
+++ b/src/code/static.js
@@ -6,6 +6,7 @@ W.static = {
     main: require("./css/wasabee.css"),
     autodraws: require("./css/autodraws.css"),
     toolbar: require("./css/toolbar.css"),
+    panes: require("./css/panes.css"),
     // fix for dialogs on mobile from iitc dev version
     // to remove on >IITC-0.30.1
     iitcfix: require("./css/iitcfix.css"),
@@ -57,6 +58,7 @@ W.static = {
     LAST_MARKER_KEY: "wasabee-last-marker-type",
     AUTO_LOAD_FAKED: "wasabee-autoload-faked",
     TRAWL_SKIP_STEPS: "wasabee-trawl-skip",
+    USE_ANDROID_PANES: "wasabee-use-android-panes",
     OAUTH_CLIENT_ID:
       "269534461245-jbnes60ebd7u0b8naba19h4vqm7ji219.apps.googleusercontent.com",
     SERVER_BASE_KEY: "wasabee-server",


### PR DESCRIPTION
Implements #193 

Add an setting to use pane on mobile (need reload)
Add a single pane on mobile (with an related pane UI on android) to show big window that generally use the whole screen : checklist, opslist, blockerlist

includes:
 - some internal to allow more that one pane (could be useful on android but doesn't look necessary)
 - factor of dialog to get jquery/iitc dialog calls in a single place
 - UI for paned dialog, replicating titlebar and button set

