### PR TITLE
internals: change operation.addLink api

### DIFF
--- a/src/code/buttons/quickdrawButton.js
+++ b/src/code/buttons/quickdrawButton.js
@@ -302,14 +302,11 @@ const QuickDrawControl = L.Handler.extend({
     if (!this._anchor2) {
       if (selectedPortal.id === this._anchor1.id) return;
       this._anchor2 = selectedPortal;
-      this._operation.addLink(
-        this._anchor1,
-        this._anchor2,
-        wX("QDBASE"),
-        this._operation.nextOrder,
-        false,
-        this._nextDrawnLinksColor
-      );
+      this._operation.addLink(this._anchor1, this._anchor2, {
+        description: wX("QDBASE"),
+        order: this._operation.nextOrder,
+        color: this._nextDrawnLinksColor,
+      });
       this._tooltip.updateContent(this._getTooltipText());
       localStorage[
         window.plugin.wasabee.static.constants.ANCHOR_TWO_KEY
@@ -322,22 +319,14 @@ const QuickDrawControl = L.Handler.extend({
       return;
     }
 
-    this._operation.addLink(
-      selectedPortal,
-      this._anchor1,
-      null,
-      this._operation.nextOrder,
-      false,
-      this._nextDrawnLinksColor
-    );
-    this._operation.addLink(
-      selectedPortal,
-      this._anchor2,
-      null,
-      this._operation.nextOrder,
-      false,
-      this._nextDrawnLinksColor
-    );
+    this._operation.addLink(selectedPortal, this._anchor1, {
+      order: this._operation.nextOrder,
+      color: this._nextDrawnLinksColor,
+    });
+    this._operation.addLink(selectedPortal, this._anchor2, {
+      order: this._operation.nextOrder,
+      color: this._nextDrawnLinksColor,
+    });
     this._tooltip.updateContent(this._getTooltipText());
   },
 
@@ -372,14 +361,10 @@ const QuickDrawControl = L.Handler.extend({
     }
 
     if (this._previous) {
-      this._operation.addLink(
-        this._previous,
-        selectedPortal,
-        null,
-        this._throwOrder++,
-        false,
-        this._nextDrawnLinksColor
-      );
+      this._operation.addLink(this._previous, selectedPortal, {
+        order: this._throwOrder++,
+        color: this._nextDrawnLinksColor,
+      });
     }
 
     // all portals, including the first
@@ -403,14 +388,10 @@ const QuickDrawControl = L.Handler.extend({
     }
 
     if (this._anchor) {
-      this._operation.addLink(
-        selectedPortal,
-        this._anchor,
-        null,
-        this._throwOrder++,
-        false,
-        this._nextDrawnLinksColor
-      );
+      this._operation.addLink(selectedPortal, this._anchor, {
+        order: this._throwOrder++,
+        color: this._nextDrawnLinksColor,
+      });
     } else this._anchor = selectedPortal;
 
     // all portals, including the first

--- a/src/code/dialogs/fanfield.js
+++ b/src/code/dialogs/fanfield.js
@@ -203,7 +203,7 @@ const FanfieldDialog = WDialog.extend({
     for (let i = available.length - 1; i >= 0; i--) {
       const wp = available[i];
       order++;
-      op.addLink(wp, this._anchor, "fan anchor", order);
+      op.addLink(wp, this._anchor, { description: "fan anchor", order: order });
 
       // skip back links if first portal
       if (i + 1 == available.length) continue;
@@ -227,12 +227,18 @@ const FanfieldDialog = WDialog.extend({
         if (crossed) break;
       }
       j--;
-      op.addLink(wp, available[j], "fan subfield", ++order);
+      op.addLink(wp, available[j], {
+        description: "fan subfield",
+        order: ++order,
+      });
       fields++;
 
       for (var k = j - 1; k > i; k--) {
         const check = available[k];
-        op.addLink(wp, check, "fan double subfield", ++order);
+        op.addLink(wp, check, {
+          description: "fan double subfield",
+          order: ++order,
+        });
         fields += 2;
       }
       // remove covered portals

--- a/src/code/dialogs/homogeneous.js
+++ b/src/code/dialogs/homogeneous.js
@@ -620,8 +620,12 @@ const HomogeneousDialog = WDialog.extend({
             : [r.portal, father, "to father", fatherOrder],
         ];
         for (const [from, to, comment, order] of data) {
-          const link = this._operation.addLink(from, to, comment, order, true);
-          link.color = this._colors[order % this._colors.length];
+          this._operation.addLink(from, to, {
+            description: comment,
+            order: order,
+            color: this._colors[order % this._colors.length],
+            replace: true,
+          });
         }
         for (const child of r.children) draw(depth + 1, child);
       }
@@ -647,39 +651,33 @@ const HomogeneousDialog = WDialog.extend({
     this._operation.addPortal(one);
     this._operation.addPortal(two);
     this._operation.addPortal(three);
-    const outer1 = this._operation.addLink(
-      two,
-      one,
-      "Outer 1",
-      (depthValue * (depthValue - 1)) / 2 + depthValue + 1,
-      true
-    );
-    outer1.color = this._colors[
-      ((depthValue * (depthValue - 1)) / 2 + depthValue + 1) %
-        this._colors.length
-    ];
-    const outer2 = this._operation.addLink(
-      three,
-      one,
-      "Outer 2",
-      (depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2,
-      true
-    );
-    outer2.color = this._colors[
-      ((depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2) %
-        this._colors.length
-    ];
-    const outer3 = this._operation.addLink(
-      three,
-      two,
-      "Outer 3",
-      (depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2,
-      true
-    );
-    outer3.color = this._colors[
-      ((depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2) %
-        this._colors.length
-    ];
+    this._operation.addLink(two, one, {
+      description: "Outer 1",
+      order: (depthValue * (depthValue - 1)) / 2 + depthValue + 1,
+      color: this._colors[
+        ((depthValue * (depthValue - 1)) / 2 + depthValue + 1) %
+          this._colors.length
+      ],
+      replace: true,
+    });
+    this._operation.addLink(three, one, {
+      description: "Outer 2",
+      order: (depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2,
+      color: this._colors[
+        ((depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2) %
+          this._colors.length
+      ],
+      replace: true,
+    });
+    this._operation.addLink(three, two, {
+      description: "Outer 3",
+      order: (depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2,
+      color: this._colors[
+        ((depthValue * (depthValue - 1)) / 2 + 2 * depthValue + 2) %
+          this._colors.length
+      ],
+      replace: true,
+    });
     draw(1, tree);
   },
 
@@ -716,14 +714,12 @@ const HomogeneousDialog = WDialog.extend({
     // link an anchor to inner portals in depth order
     const drawBackLink = (depth, r, anchor, order) => {
       if (r.portal) {
-        const link = this._operation.addLink(
-          anchor,
-          r.portal,
-          "intern link",
-          order + 1,
-          true
-        );
-        link.color = this._colors[order % this._colors.length];
+        this._operation.addLink(anchor, r.portal, {
+          description: "intern link",
+          order: order + 1,
+          color: this._colors[order % this._colors.length],
+          replace: true,
+        });
         for (const child of r.children)
           if (child.anchors.includes(anchor))
             drawBackLink(depth + 1, child, anchor, order + 1);
@@ -740,14 +736,11 @@ const HomogeneousDialog = WDialog.extend({
       )[0];
       // draw outer link
       for (const anchor of [pOne, pTwo]) {
-        const link = this._operation.addLink(
-          pThree,
-          anchor,
-          "",
-          order + 1,
-          true
-        );
-        link.color = this._colors[order % this._colors.length];
+        this._operation.addLink(pThree, anchor, {
+          order: order + 1,
+          color: this._colors[order % this._colors.length],
+          replace: true,
+        });
       }
       if (!r.portal) return order + 1;
       // draw inner link from 3
@@ -772,8 +765,12 @@ const HomogeneousDialog = WDialog.extend({
     drawDebug(depthValue, tree);
 
     for (const p of tree.anchors) this._operation.addPortal(p);
-    const outerBase = this._operation.addLink(two, one, "Outer base", 1, true);
-    outerBase.color = this._colors[0];
+    this._operation.addLink(two, one, {
+      description: "Outer base",
+      order: 1,
+      color: this._colors[0],
+      replace: true,
+    });
     draw(1, tree, one, two);
   },
 

--- a/src/code/dialogs/linkDialog.js
+++ b/src/code/dialogs/linkDialog.js
@@ -90,12 +90,10 @@ const LinkDialog = WDialog.extend({
       L.DomEvent.stop(ev);
       if (this._source && this._anchor1) {
         const operation = getSelectedOperation();
-        operation.addLink(
-          this._source,
-          this._anchor1,
-          this._desc.value,
-          operation.nextOrder
-        );
+        operation.addLink(this._source, this._anchor1, {
+          description: this._desc.value,
+          order: operation.nextOrder,
+        });
       } else {
         alert("Select both Source and Anchor 1");
       }
@@ -134,12 +132,10 @@ const LinkDialog = WDialog.extend({
       L.DomEvent.stop(ev);
       if (this._source && this._anchor2) {
         const operation = getSelectedOperation();
-        operation.addLink(
-          this._source,
-          this._anchor2,
-          this._desc.value,
-          operation.nextOrder
-        );
+        operation.addLink(this._source, this._anchor2, {
+          description: this._desc.value,
+          order: operation.nextOrder,
+        });
       } else {
         alert(wX("SEL_SRC_ANC2"));
       }
@@ -153,20 +149,16 @@ const LinkDialog = WDialog.extend({
       if (!this._source) alert(wX("SEL_SRC_PORT"));
       const operation = getSelectedOperation();
       if (this._anchor1) {
-        operation.addLink(
-          this._source,
-          this._anchor1,
-          this._desc.value,
-          operation.nextOrder
-        );
+        operation.addLink(this._source, this._anchor1, {
+          description: this._desc.value,
+          order: operation.nextOrder,
+        });
       }
       if (this._anchor2) {
-        operation.addLink(
-          this._source,
-          this._anchor2,
-          this._desc.value,
-          operation.nextOrder
-        );
+        operation.addLink(this._source, this._anchor2, {
+          description: this._desc.value,
+          order: operation.nextOrder,
+        });
       }
     });
     this._desc = L.DomUtil.create("input", "desc", container);

--- a/src/code/dialogs/madrid.js
+++ b/src/code/dialogs/madrid.js
@@ -276,9 +276,15 @@ const MadridDialog = MultimaxDialog.extend({
     this._operation.startBatchMode();
 
     // ignore order + direction
-    this._operation.addLink(spines[0][0], spines[1][0], "inner field");
-    this._operation.addLink(spines[1][0], spines[2][0], "inner field");
-    this._operation.addLink(spines[2][0], spines[0][0], "inner field");
+    this._operation.addLink(spines[0][0], spines[1][0], {
+      description: "inner field",
+    });
+    this._operation.addLink(spines[1][0], spines[2][0], {
+      description: "inner field",
+    });
+    this._operation.addLink(spines[2][0], spines[0][0], {
+      description: "inner field",
+    });
 
     const indices = [1, 1, 1];
 
@@ -307,8 +313,10 @@ const MadridDialog = MultimaxDialog.extend({
       }
       if (!this.fieldCoversPortal(p, pTwo, pThree, pOne))
         console.log("well, this doesn't work here...");
-      const toTwo = this._operation.addLink(p, pTwo, "link");
-      const toThree = this._operation.addLink(p, pThree, "link");
+      const toTwo = this._operation.addLink(p, pTwo, { description: "link" });
+      const toThree = this._operation.addLink(p, pThree, {
+        description: "link",
+      });
       toTwo.zone = spineOrder[0] + 1;
       toThree.zone = spineOrder[0] + 1;
 
@@ -336,7 +344,10 @@ const MadridDialog = MultimaxDialog.extend({
       return 0;
     }
     this._operation.startBatchMode(); // bypass save and crosslinks checks
-    this._operation.addLink(this._anchorOne, this._anchorTwo, "madrid base", 1);
+    this._operation.addLink(this._anchorOne, this._anchorTwo, {
+      description: "madrid base",
+      order: 1,
+    });
 
     let len = 0;
     const [len1, order1, last1] = this.MM(

--- a/src/code/dialogs/multimaxDialog.js
+++ b/src/code/dialogs/multimaxDialog.js
@@ -148,7 +148,10 @@ const MultimaxDialog = WDialog.extend({
     );
 
     if (base)
-      this._operation.addLink(pOne, pTwo, commentPrefix + "base", ++order);
+      this._operation.addLink(pOne, pTwo, {
+        description: commentPrefix + "base",
+        oder: ++order,
+      });
 
     if (!Array.isArray(sequence) || !sequence.length) {
       // alert("No layers found");
@@ -163,10 +166,19 @@ const MultimaxDialog = WDialog.extend({
         console.log("skipping: " + node);
         continue;
       }
-      this._operation.addLink(p, pOne, commentPrefix + "link", ++order);
-      this._operation.addLink(p, pTwo, commentPrefix + "link", ++order);
+      this._operation.addLink(p, pOne, {
+        description: commentPrefix + "link",
+        order: ++order,
+      });
+      this._operation.addLink(p, pTwo, {
+        description: commentPrefix + "link",
+        order: ++order,
+      });
       if (this._flcheck.checked && prev) {
-        this._operation.addLink(p, prev, commentPrefix + "back link", ++order);
+        this._operation.addLink(p, prev, {
+          description: commentPrefix + "back link",
+          order: ++order,
+        });
       }
       prev = p;
     }

--- a/src/code/dialogs/saveLinks.js
+++ b/src/code/dialogs/saveLinks.js
@@ -98,17 +98,13 @@ const SaveLinksDialog = WDialog.extend({
     for (const p of getAllPortalsLinked(operation, this._anchor)) {
       if (p.id == this._anchor.id) continue;
       if (p.comment === "out") {
-        operation.addLink(
-          this._anchor,
-          p,
-          "Save Links on Portal (Outbound from anchor)"
-        );
+        operation.addLink(this._anchor, p, {
+          description: "Save Links (Outbound from anchor)",
+        });
       } else {
-        operation.addLink(
-          p,
-          this._anchor,
-          "Save Links on Portal (Inbound to anchor)"
-        );
+        operation.addLink(p, this._anchor, {
+          description: "Save Links (Inbound to anchor)",
+        });
       }
     }
     operation.endBatchMode();

--- a/src/code/dialogs/starburst.js
+++ b/src/code/dialogs/starburst.js
@@ -100,7 +100,7 @@ const StarburstDialog = WDialog.extend({
     operation.startBatchMode();
     for (const p of getAllPortalsOnScreen(operation)) {
       if (p.id == this._anchor.id) continue;
-      operation.addLink(p, this._anchor, "auto starburst");
+      operation.addLink(p, this._anchor, { description: "auto starburst" });
     }
     operation.endBatchMode();
   },

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -641,7 +641,7 @@ export default class WasabeeOp {
   }
 
   // options: {description,order,color,replace}
-  addLink(fromPortal, toPortal, options) {
+  addLink(fromPortal, toPortal, options = {}) {
     console.assert(fromPortal && toPortal, "missing portal for link");
     if (fromPortal.id === toPortal.id) {
       console.debug(
@@ -649,8 +649,6 @@ export default class WasabeeOp {
       );
       return null;
     }
-
-    if (!options) options = {};
 
     this.addAnchor(fromPortal);
     this.addAnchor(toPortal);

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -640,14 +640,8 @@ export default class WasabeeOp {
     return false;
   }
 
-  addLink(
-    fromPortal,
-    toPortal,
-    description,
-    order,
-    replace = false,
-    color = null
-  ) {
+  // options: {description,order,color,replace}
+  addLink(fromPortal, toPortal, options) {
     console.assert(fromPortal && toPortal, "missing portal for link");
     if (fromPortal.id === toPortal.id) {
       console.debug(
@@ -656,32 +650,32 @@ export default class WasabeeOp {
       return null;
     }
 
+    if (!options) options = {};
+
     this.addAnchor(fromPortal);
     this.addAnchor(toPortal);
 
     const existingLink = this.getLink(fromPortal, toPortal);
 
     const link =
-      existingLink && replace
+      existingLink && options.replace
         ? existingLink
         : new WasabeeLink(
             {
               fromPortalId: fromPortal.id,
               toPortalId: toPortal.id,
-              description: description,
-              throwOrderPos: order,
             },
             this
           );
-    link.description = description;
-    if (order) link.opOrder = order;
-    if (color) link.color = color;
+    if (options.description) link.description = options.description;
+    if (options.order) link.opOrder = options.order;
+    if (options.color) link.color = options.color;
 
     if (!existingLink) {
       this.links.push(link);
       this.update(true);
       this.runCrosslinks();
-    } else if (replace) {
+    } else if (options.replace) {
       this.update(true);
       this.runCrosslinks();
     } else {


### PR DESCRIPTION
Current `operation.addLink` is getting uglier to match different use cases, adding arguments...
Suggestions are:
 1. `operation.addLink(fromWP, toWP, options)`: addLink adds wPortals in the operation if missing and takes care of the creation of a wasabee link
 2. `operation.addLink(wLink, replace?)`: the caller needs to add the wPortals and to create the wLink

in both case, the method returns the operation link 

The PR currently implements (1)