### PR TITLE
Background Ops

### DIFF
--- a/src/code/css/wasabee.css
+++ b/src/code/css/wasabee.css
@@ -714,6 +714,9 @@
 .wasabee-dialog-ops .wasabee-table .actions a {
     padding: .25em
 }
+.wasabee-dialog-ops .wasabee-table.hideOps .visibility {
+  display: none;
+}
 .wasabee-dialog-checklist {
 }
 .wasabee-dialog-perms {

--- a/src/code/dialogs/mergeDialog.js
+++ b/src/code/dialogs/mergeDialog.js
@@ -3,6 +3,7 @@ import wX from "../wX";
 import WasabeeOp from "../operation";
 import Sortable from "../sortable";
 import { getSelectedOperation, makeSelectedOperation } from "../selectedOp";
+import { drawBackgroundOp } from "../mapDrawing";
 
 const MergeDialog = WDialog.extend({
   statics: {
@@ -16,7 +17,14 @@ const MergeDialog = WDialog.extend({
 
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
+    this._layer = new L.LayerGroup();
+    this._layer.addTo(window.map);
     this._displayDialog();
+  },
+
+  removeHooks: function () {
+    WDialog.prototype.addHooks.call(this);
+    this._layer.remove();
   },
 
   _displayDialog: function () {
@@ -27,6 +35,15 @@ const MergeDialog = WDialog.extend({
     this._opRebase.cleanAll();
     this._opRebase.remoteChanged = this.options.opOwn.remoteChanged;
     this._opRebase.localchanged = this.options.opOwn.localchanged;
+
+    const style = {
+      dashArray: [2, 8],
+      opacity: 0.86,
+      weight: 4,
+      color: "blue",
+      interactive: false,
+    };
+    drawBackgroundOp(this._opRebase, this._layer, style);
 
     const content = L.DomUtil.create("div", "container");
     const desc = L.DomUtil.create("div", "desc", content);

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -182,12 +182,13 @@ const OpsDialog = WDialog.extend({
         sort: null,
         format: (cell, value, op) => {
           // background
-          const background = L.DomUtil.create("a", "", cell);
-          background.textContent = op.background ? "👀" : "☽";
+          const background = L.DomUtil.create("input", null, cell);
+          background.type = "checkbox";
+          background.checked = op.background;
           background.title = op.background
             ? "Disable background"
             : "Show in background";
-          L.DomEvent.on(cell, "click", (ev) => {
+          L.DomEvent.on(background, "change", (ev) => {
             L.DomEvent.stop(ev);
             setOpBackground(op.id, !op.background);
           });

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -29,7 +29,6 @@ const OpsDialog = WDialog.extend({
   addHooks: function () {
     WDialog.prototype.addHooks.call(this);
     window.map.on("wasabeeUIUpdate", this.update, this);
-    window.map.on("wasabee:op:background", this.update, this);
     window.map.on("wasabee:op:delete", this.update, this);
     this._displayDialog();
   },
@@ -37,7 +36,6 @@ const OpsDialog = WDialog.extend({
   removeHooks: function () {
     WDialog.prototype.removeHooks.call(this);
     window.map.off("wasabeeUIUpdate", this.update, this);
-    window.map.off("wasabee:op:background", this.update, this);
     window.map.off("wasabee:op:delete", this.update, this);
   },
 
@@ -190,6 +188,10 @@ const OpsDialog = WDialog.extend({
             : "Show in background";
           L.DomEvent.on(background, "change", (ev) => {
             L.DomEvent.stop(ev);
+            const background = ev.target;
+            background.title = !op.background
+              ? "Disable background"
+              : "Show in background";
             setOpBackground(op.id, !op.background);
           });
         },

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -1,7 +1,12 @@
 import { initCrossLinks } from "./crosslinks";
 import initServer from "./server";
 import { setupLocalStorage, initSelectedOperation } from "./selectedOp";
-import { drawMap, drawAgents, drawBackgroundOps } from "./mapDrawing";
+import {
+  drawMap,
+  drawAgents,
+  drawBackgroundOps,
+  drawBackgroundOp,
+} from "./mapDrawing";
 import addButtons from "./addButtons";
 import { setupToolbox } from "./toolbox";
 import { initFirebase, postToFirebase } from "./firebaseSupport";
@@ -11,6 +16,7 @@ import { initSkin, changeSkin } from "./skin";
 import { WPane } from "./leafletClasses";
 import OperationChecklist from "./dialogs/checklist";
 import WasabeeMe from "./me";
+import WasabeeOp from "./operation";
 import { openDB } from "idb";
 const Wasabee = window.plugin.wasabee;
 
@@ -100,8 +106,9 @@ window.plugin.wasabee.init = async () => {
   window.map.on("wasabee:op:hide", () => {
     drawBackgroundOps();
   });
-  window.map.on("wasabee:op:show", () => {
-    drawBackgroundOps();
+  window.map.on("wasabee:op:show", (opID) => {
+    if (Wasabee._selectedOp && Wasabee._selectedOp.ID !== opID)
+      WasabeeOp.load(opID).then(drawBackgroundOp);
   });
 
   // Android panes

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -160,6 +160,9 @@ window.plugin.wasabee.init = async () => {
   // run crosslinks
   window.map.fire("wasabeeCrosslinks", { reason: "startup" }, false);
 
+  // draw background ops
+  drawBackgroundOps();
+
   // if the browser was restarted and the cookie nuked, but localstorge[me]
   // has not yet expired, we would think we were logged in when really not
   // this forces an update on reload

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -77,7 +77,7 @@ window.plugin.wasabee.init = async () => {
   window.addLayerGroup(
     "Wasabee Background Ops",
     Wasabee.backgroundOpsGroup,
-    false
+    true
   );
 
   // standard hook, add our call to it

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -103,12 +103,13 @@ window.plugin.wasabee.init = async () => {
   window.map.on("wasabee:op:select", () => {
     drawBackgroundOps();
   });
-  window.map.on("wasabee:op:hide", () => {
-    drawBackgroundOps();
-  });
-  window.map.on("wasabee:op:show", (opID) => {
-    if (Wasabee._selectedOp && Wasabee._selectedOp.ID !== opID)
-      WasabeeOp.load(opID).then(drawBackgroundOp);
+  window.map.on("wasabee:op:background", (data) => {
+    if (data.background) {
+      if (Wasabee._selectedOp && Wasabee._selectedOp.ID !== data.opID)
+        WasabeeOp.load(data.opID).then(drawBackgroundOp);
+    } else {
+      drawBackgroundOps();
+    }
   });
 
   // Android panes

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -1,10 +1,6 @@
 import { initCrossLinks } from "./crosslinks";
 import initServer from "./server";
-import {
-  setupLocalStorage,
-  initSelectedOperation,
-  opsList,
-} from "./selectedOp";
+import { setupLocalStorage, initSelectedOperation } from "./selectedOp";
 import { drawMap, drawAgents, drawBackgroundOps } from "./mapDrawing";
 import addButtons from "./addButtons";
 import { setupToolbox } from "./toolbox";
@@ -98,9 +94,14 @@ window.plugin.wasabee.init = async () => {
     sendLocation();
   });
 
-  window.map.on("wasabee:op:select", async (data) => {
-    const ol = await opsList();
-    drawBackgroundOps(ol.filter((id) => id !== data.current));
+  window.map.on("wasabee:op:select", () => {
+    drawBackgroundOps();
+  });
+  window.map.on("wasabee:op:hide", () => {
+    drawBackgroundOps();
+  });
+  window.map.on("wasabee:op:show", () => {
+    drawBackgroundOps();
   });
 
   // Android panes
@@ -122,6 +123,9 @@ window.plugin.wasabee.init = async () => {
       obj.layer === Wasabee.markerLayerGroup
     ) {
       window.map.fire("wasabeeUIUpdate", { reason: "layeradd" }, false);
+    }
+    if (obj.layer === Wasabee.backgroundOpsGroup) {
+      drawBackgroundOps();
     }
   });
 

--- a/src/code/init.js
+++ b/src/code/init.js
@@ -1,7 +1,11 @@
 import { initCrossLinks } from "./crosslinks";
 import initServer from "./server";
-import { setupLocalStorage, initSelectedOperation } from "./selectedOp";
-import { drawMap, drawAgents } from "./mapDrawing";
+import {
+  setupLocalStorage,
+  initSelectedOperation,
+  opsList,
+} from "./selectedOp";
+import { drawMap, drawAgents, drawBackgroundOps } from "./mapDrawing";
 import addButtons from "./addButtons";
 import { setupToolbox } from "./toolbox";
 import { initFirebase, postToFirebase } from "./firebaseSupport";
@@ -67,6 +71,13 @@ window.plugin.wasabee.init = async () => {
   window.addLayerGroup("Wasabee Draw Markers", Wasabee.markerLayerGroup, true);
   window.addLayerGroup("Wasabee Agents", Wasabee.agentLayerGroup, true);
 
+  Wasabee.backgroundOpsGroup = new L.LayerGroup();
+  window.addLayerGroup(
+    "Wasabee Background Ops",
+    Wasabee.backgroundOpsGroup,
+    false
+  );
+
   // standard hook, add our call to it
   window.addHook("mapDataRefreshStart", () => {
     drawAgents(Wasabee._selectedOp);
@@ -85,6 +96,11 @@ window.plugin.wasabee.init = async () => {
   window.addResumeFunction(() => {
     window.map.fire("wasabeeUIUpdate", { reason: "resume" }, false);
     sendLocation();
+  });
+
+  window.map.on("wasabee:op:select", async (data) => {
+    const ol = await opsList();
+    drawBackgroundOps(ol.filter((id) => id !== data.current));
   });
 
   // Android panes

--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -4,7 +4,7 @@ import WasabeeTeam from "./team";
 import WasabeeAgent from "./agent";
 import WasabeeOp from "./operation";
 import { newColors } from "./auxiliar";
-import { getSelectedOperation, opsList, hiddenOpsList } from "./selectedOp";
+import { getSelectedOperation, opsList } from "./selectedOp";
 
 const Wasabee = window.plugin.wasabee;
 
@@ -112,14 +112,13 @@ export async function drawBackgroundOps(opIDs) {
   if (window.isLayerGroupDisplayed("Wasabee Background Ops") === false) return;
   Wasabee.backgroundOpsGroup.clearLayers();
 
-  if (opIDs === undefined) {
-    const sop = getSelectedOperation().ID;
-    const hol = hiddenOpsList();
-    opIDs = await opsList();
-    opIDs = opIDs.filter((id) => id !== sop && !hol.includes(id));
-  }
+  const sop = getSelectedOperation().ID;
+  if (opIDs === undefined) opIDs = await opsList();
+
   for (const opID of opIDs) {
-    WasabeeOp.load(opID).then(drawBackgroundOp);
+    if (opID === sop) continue;
+    const op = await WasabeeOp.load(opID);
+    if (op.background) drawBackgroundOp(op);
   }
 }
 

--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -4,7 +4,7 @@ import WasabeeTeam from "./team";
 import WasabeeAgent from "./agent";
 import WasabeeOp from "./operation";
 import { newColors } from "./auxiliar";
-import { getSelectedOperation } from "./selectedOp";
+import { getSelectedOperation, opsList, hiddenOpsList } from "./selectedOp";
 
 const Wasabee = window.plugin.wasabee;
 
@@ -108,12 +108,16 @@ function resetLinks(operation) {
   }
 }
 
-export function drawBackgroundOps(opIDs) {
+export async function drawBackgroundOps() {
   if (window.isLayerGroupDisplayed("Wasabee Background Ops") === false) return;
   Wasabee.backgroundOpsGroup.clearLayers();
 
-  for (const opID of opIDs) {
-    WasabeeOp.load(opID).then(drawBackgroundOp);
+  const sop = getSelectedOperation().ID;
+  const ol = await opsList();
+  const hol = hiddenOpsList();
+  for (const opID of ol) {
+    if (opID !== sop && !hol.includes(opID))
+      WasabeeOp.load(opID).then(drawBackgroundOp);
   }
 }
 

--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -108,16 +108,18 @@ function resetLinks(operation) {
   }
 }
 
-export async function drawBackgroundOps() {
+export async function drawBackgroundOps(opIDs) {
   if (window.isLayerGroupDisplayed("Wasabee Background Ops") === false) return;
   Wasabee.backgroundOpsGroup.clearLayers();
 
-  const sop = getSelectedOperation().ID;
-  const ol = await opsList();
-  const hol = hiddenOpsList();
-  for (const opID of ol) {
-    if (opID !== sop && !hol.includes(opID))
-      WasabeeOp.load(opID).then(drawBackgroundOp);
+  if (opIDs === undefined) {
+    const sop = getSelectedOperation().ID;
+    const hol = hiddenOpsList();
+    opIDs = await opsList();
+    opIDs = opIDs.filter((id) => id !== sop && !hol.includes(id));
+  }
+  for (const opID of opIDs) {
+    WasabeeOp.load(opID).then(drawBackgroundOp);
   }
 }
 

--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -123,19 +123,19 @@ export async function drawBackgroundOps(opIDs) {
   }
 }
 
-function drawBackgroundOp(operation) {
+export function drawBackgroundOp(operation, layerGroup, style) {
   if (!operation) return;
   if (!operation.links || operation.links.length == 0) return;
+
+  if (!layerGroup) layerGroup = Wasabee.backgroundOpsGroup;
+  if (!style) style = Wasabee.skin.backgroundLinkStyle;
 
   for (const link of operation.links) {
     const latLngs = link.getLatLngs(operation);
     if (!latLngs) continue;
 
-    const newlink = new L.GeodesicPolyline(
-      latLngs,
-      Wasabee.skin.backgroundLinkStyle
-    );
-    newlink.addTo(Wasabee.backgroundOpsGroup);
+    const newlink = new L.GeodesicPolyline(latLngs, style);
+    newlink.addTo(layerGroup);
   }
 }
 

--- a/src/code/mapDrawing.js
+++ b/src/code/mapDrawing.js
@@ -2,6 +2,7 @@ import WasabeeMe from "./me";
 import WasabeeAnchor from "./anchor";
 import WasabeeTeam from "./team";
 import WasabeeAgent from "./agent";
+import WasabeeOp from "./operation";
 import { newColors } from "./auxiliar";
 import { getSelectedOperation } from "./selectedOp";
 
@@ -104,6 +105,31 @@ function resetLinks(operation) {
 
   for (const l of operation.links) {
     addLink(l, operation);
+  }
+}
+
+export function drawBackgroundOps(opIDs) {
+  if (window.isLayerGroupDisplayed("Wasabee Background Ops") === false) return;
+  Wasabee.backgroundOpsGroup.clearLayers();
+
+  for (const opID of opIDs) {
+    WasabeeOp.load(opID).then(drawBackgroundOp);
+  }
+}
+
+function drawBackgroundOp(operation) {
+  if (!operation) return;
+  if (!operation.links || operation.links.length == 0) return;
+
+  for (const link of operation.links) {
+    const latLngs = link.getLatLngs(operation);
+    if (!latLngs) continue;
+
+    const newlink = new L.GeodesicPolyline(
+      latLngs,
+      Wasabee.skin.backgroundLinkStyle
+    );
+    newlink.addTo(Wasabee.backgroundOpsGroup);
   }
 }
 

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -92,11 +92,8 @@ export default class WasabeeMarker {
     return this._state;
   }
 
-  async popupContent(marker) {
-    const operation = getSelectedOperation();
-    if (operation == null) {
-      console.log("null op in marker?");
-    }
+  async popupContent(marker, operation) {
+    if (!operation) operation = getSelectedOperation();
 
     const portal = operation.getPortal(this.portalId);
     if (portal == null) {

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -48,6 +48,8 @@ export default class WasabeeOp {
 
     this.fetchedOp = obj.fetchedOp ? obj.fetchedOp : null;
 
+    this.background = !!obj.background;
+
     if (!this.links) this.links = new Array();
     if (!this.markers) this.markers = new Array();
     if (!this.blockers) this.blockers = new Array();
@@ -122,6 +124,7 @@ export default class WasabeeOp {
     json.blockers = this.blockers;
     json.keysonhand = this.keysonhand;
     json.teamlist = this.teamlist;
+    json.background = this.background;
 
     // store to localStorage -- for now
     // localStorage[this.ID] = JSON.stringify(json); // deactivated now

--- a/src/code/selectedOp.js
+++ b/src/code/selectedOp.js
@@ -60,7 +60,9 @@ export async function loadNewDefaultOp() {
 // only this should write to _selectedOp
 export async function makeSelectedOperation(opID) {
   // _selectedOp is null at first load (or page reload), should never be after that
+  let previousID;
   if (window.plugin.wasabee._selectedOp != null) {
+    previousID = window.plugin.wasabee._selectedOp.ID;
     if (opID == window.plugin.wasabee._selectedOp.ID) {
       console.log(
         "makeSelectedOperation called on the current op; replacing with version from local store. not saving live changes first"
@@ -94,6 +96,11 @@ export async function makeSelectedOperation(opID) {
     { reason: "makeSelectedOperation" },
     false
   );
+  if (previousID !== opID)
+    window.map.fire("wasabee:op:select", {
+      previous: previousID,
+      current: opID,
+    });
   // return window.plugin.wasabee._selectedOp;
 }
 

--- a/src/code/selectedOp.js
+++ b/src/code/selectedOp.js
@@ -205,7 +205,8 @@ export function hiddenOpsList() {
 }
 
 export async function setOpBackground(opID, background) {
-  const op = await WasabeeOp.load(opID);
+  const sop = getSelectedOperation();
+  const op = sop.ID === opID ? sop : await WasabeeOp.load(opID);
   if (op.background == background) return;
   op.background = background;
   await op.store();

--- a/src/code/selectedOp.js
+++ b/src/code/selectedOp.js
@@ -158,19 +158,25 @@ export async function addOperation(opID) {
 
 //** This function shows an operation to the main list */
 export function showOperation(opID) {
-  const hiddenOps = hiddenOpsList().filter((ID) => ID != opID);
-  localStorage[
-    window.plugin.wasabee.static.constants.OPS_LIST_HIDDEN_KEY
-  ] = JSON.stringify(hiddenOps);
+  const hiddenOps = hiddenOpsList();
+  if (hiddenOps.includes(opID)) {
+    localStorage[
+      window.plugin.wasabee.static.constants.OPS_LIST_HIDDEN_KEY
+    ] = JSON.stringify(hiddenOps.filter((ID) => ID != opID));
+    window.map.fire("wasabee:op:show", opID);
+  }
 }
 
 //** This function hides an operation to the main list */
 export function hideOperation(opID) {
   const hiddenOps = hiddenOpsList();
-  if (!hiddenOps.includes(opID)) hiddenOps.push(opID);
-  localStorage[
-    window.plugin.wasabee.static.constants.OPS_LIST_HIDDEN_KEY
-  ] = JSON.stringify(hiddenOps);
+  if (!hiddenOps.includes(opID)) {
+    hiddenOps.push(opID);
+    localStorage[
+      window.plugin.wasabee.static.constants.OPS_LIST_HIDDEN_KEY
+    ] = JSON.stringify(hiddenOps);
+    window.map.fire("wasabee:op:hide", opID);
+  }
 }
 
 export function resetHiddenOps() {

--- a/src/code/selectedOp.js
+++ b/src/code/selectedOp.js
@@ -147,6 +147,7 @@ export async function removeOperation(opID) {
   const ops = ol.filter((ID) => ID != opID);
   storeOpsList(ops);
   await WasabeeOp.delete(opID);
+  window.map.fire("wasabee:op:delete", opID);
 }
 
 //** This function adds an operation to the main list */
@@ -154,6 +155,7 @@ export async function addOperation(opID) {
   const ops = await opsList();
   if (!ops.includes(opID)) ops.push(opID);
   storeOpsList(ops);
+  window.map.fire("wasabee:op:add", opID);
 }
 
 //** This function shows an operation to the main list */
@@ -163,7 +165,7 @@ export function showOperation(opID) {
     localStorage[
       window.plugin.wasabee.static.constants.OPS_LIST_HIDDEN_KEY
     ] = JSON.stringify(hiddenOps.filter((ID) => ID != opID));
-    window.map.fire("wasabee:op:show", opID);
+    window.map.fire("wasabee:op:showhide", { opID: opID, show: true });
   }
 }
 
@@ -175,7 +177,7 @@ export function hideOperation(opID) {
     localStorage[
       window.plugin.wasabee.static.constants.OPS_LIST_HIDDEN_KEY
     ] = JSON.stringify(hiddenOps);
-    window.map.fire("wasabee:op:hide", opID);
+    window.map.fire("wasabee:op:showhide", { opID: opID, show: false });
   }
 }
 
@@ -200,6 +202,17 @@ export function hiddenOpsList() {
   } catch {
     return [];
   }
+}
+
+export async function setOpBackground(opID, background) {
+  const op = await WasabeeOp.load(opID);
+  if (op.background == background) return;
+  op.background = background;
+  await op.store();
+  window.map.fire("wasabee:op:background", {
+    opID: opID,
+    background: background,
+  });
 }
 
 export async function opsList(hidden = true) {

--- a/src/code/skin.js
+++ b/src/code/skin.js
@@ -9,6 +9,7 @@ export function initSkin() {
   Wasabee.skin.layerTypes = new Map(Wasabee.static.layerTypes);
   Wasabee.skin.linkStyle = Wasabee.static.linkStyle;
   Wasabee.skin.selfBlockStyle = Wasabee.static.selfBlockStyle;
+  Wasabee.skin.backgroundLinkStyle = Wasabee.static.backgroundLinkStyle;
   Wasabee.skin.anchorTemplate = Wasabee.static.anchorTemplate;
   Wasabee.skin.strings = Object.assign({}, Wasabee.static.strings);
 

--- a/src/code/static.js
+++ b/src/code/static.js
@@ -138,7 +138,6 @@ W.static.selfBlockStyle = {
 
 W.static.backgroundLinkStyle = {
   dashArray: [8, 5],
-  assignedDashArray: [8, 5],
   opacity: 0.4,
   weight: 2,
   color: "green",

--- a/src/code/static.js
+++ b/src/code/static.js
@@ -136,6 +136,15 @@ W.static.selfBlockStyle = {
   weight: 3,
 };
 
+W.static.backgroundLinkStyle = {
+  dashArray: [8, 5],
+  assignedDashArray: [8, 5],
+  opacity: 0.4,
+  weight: 2,
+  color: "green",
+  interactive: false,
+};
+
 W.static.anchorTemplate = require("!raw-loader?esModule=false!./images/pin_custom.svg");
 
 // https://leafletjs.com/reference-1.0.3.html#path


### PR DESCRIPTION
Introduce the abilities to render the **links** of multiple OPs in the background.
API can be used for merge preview 

Changes:
 - add background OPs layer enabled by default
 - client-side  only `op.background` field to control whether or not an op has to be drawn in background
 - API to draw the links of an op to any layergroup with a style
   - used for merge preview
 - move the hidden ops setting to last dialog and use a checkbox (reminder: this field is specific to this dialog)
 - add some wasabee events:
   - `wasabee:op:select` with data `{previous, current}` the previous and current op ID, fired when another op is selected 
   - `wasabee:op:add` with data `opID` the new op ID
   - `wasabee:op:delete` with data `opID` the deleted op ID, fired **after* the deletion of the op
   - `wasabee:op:showhide` with data `{opID, show}`, fired when the user (un)check the corresponding checkbox in the ops list
   - `wasabee:op:background` with data `{opID, background}`, fired (*after* storing) when an op background setting changes

See #202 