### PR TITLE
Color picker close to its button on Chrome

### DIFF
--- a/src/code/buttons/quickdrawButton.js
+++ b/src/code/buttons/quickdrawButton.js
@@ -17,18 +17,6 @@ const QuickdrawButton = WButton.extend({
     this._container = container;
     this.type = QuickdrawButton.TYPE;
 
-    this.picker = null;
-    this.picker = L.DomUtil.create("input", "", this.button);
-    this.picker.type = "color";
-    this.picker.value = "#000000"; // just need a default value that is not in the displayed list
-    this.picker.style.display = "none";
-    this.picker.setAttribute("list", "wasabee-colors-datalist");
-
-    L.DomEvent.on(this.picker, "change", (ev) => {
-      this.handler._nextDrawnLinksColor = ev.target.value;
-      this.picker.value = ev.target.value;
-    });
-
     this.button = this._createButton({
       title: this.title,
       container: container,
@@ -37,9 +25,19 @@ const QuickdrawButton = WButton.extend({
       context: this.handler,
     });
 
+    this.picker = L.DomUtil.create("input", "hidden-color-picker");
+    this.picker.type = "color";
+    this.picker.value = "#000000"; // just need a default value that is not in the displayed list
+    this.picker.setAttribute("list", "wasabee-colors-datalist");
+
+    L.DomEvent.on(this.picker, "change", (ev) => {
+      this.handler._nextDrawnLinksColor = ev.target.value;
+    });
+
     this._changeColorSubAction = {
       title: wX("QD BUTTON CHANGE COLOR"),
       text: wX("QD CHANGE COLOR"),
+      html: this.picker,
       callback: () => {
         this.picker.click();
       },

--- a/src/code/css/wasabee.css
+++ b/src/code/css/wasabee.css
@@ -870,3 +870,13 @@ a.wasabee-portal.res { color: rgb(0, 135, 255) !important; }
 .wasabee-dialog-merge .details .wasabee-table code {
   display: block;
 }
+
+/* color pickers */
+.hidden-color-picker {
+  visibility: hidden;
+  width: 0;
+  height: 0;
+  border: 0;
+  padding: 0;
+  margin: 0;
+}

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -297,7 +297,7 @@ export const WButton = L.Class.extend({
       options.className || "",
       options.container
     );
-    link.href = "#";
+
     if (options.text) link.innerHTML = options.text;
 
     if (options.buttonImage) {
@@ -310,63 +310,14 @@ export const WButton = L.Class.extend({
       link.title = options.title;
     }
 
-    if (this._isTouch()) {
-      L.DomEvent.on(link, "touchstart", L.DomEvent.stopPropagation)
-        .on(link, "touchstart", L.DomEvent.preventDefault)
-        .on(link, "touchstart", this.touchstart, options.context)
-        .on(link, "touchend", this.touchend, options.context)
-        .on(link, "touchmove", this.touchmove, options.context);
-    } else {
-      L.DomEvent.on(link, "click", L.DomEvent.stopPropagation)
-        .on(link, "mousedown", L.DomEvent.stopPropagation)
-        .on(link, "dblclick", L.DomEvent.stopPropagation)
-        .on(link, "click", L.DomEvent.preventDefault)
-        .on(link, "click", options.callback, options.context);
-    }
+    L.DomEvent.disableClickPropagation(link);
+    L.DomEvent.on(link, "click", options.callback, options.context);
 
     return link;
   },
 
-  _touches: null,
-
-  touchstart: function (ev) {
-    this._touches = ev.changedTouches[0].target.id;
-    console.log("first touch", this._touches);
-    if (!this._enabled) this.enable();
-  },
-
-  touchend: function (ev) {
-    this._touches = ev.changedTouches[0].target.id;
-    console.log("last touch target", this._touches);
-    if (this._enabled) this.disable();
-  },
-
-  touchmove: function (ev) {
-    if (ev.changedTouches[0].target.id != this._touches) {
-      this._touches = ev.changedTouches[0].target.id;
-      console.log("new touch target", this._touches);
-    }
-  },
-
-  _disposeButton: function (button, callback) {
-    console.log("WButton _disposeButton");
-    L.DomEvent.off(button, "click", L.DomEvent.stopPropagation)
-      .off(button, "mousedown", L.DomEvent.stopPropagation)
-      .off(button, "dblclick", L.DomEvent.stopPropagation)
-      .off(button, "click", L.DomEvent.preventDefault)
-      .off(button, "touchstart", L.DomEvent.preventDefault)
-      .off(button, "touchend", L.DomEvent.preventDefault)
-      .off(button, "click", callback);
-  },
-
   _createSubActions: function (buttons) {
     const container = L.DomUtil.create("ul", "wasabee-actions");
-    L.DomEvent.on(container, "touchenter", (ev) => {
-      console.log("touchenter", ev);
-    });
-    L.DomEvent.on(container, "touchleave", (ev) => {
-      console.log("touchleave", ev);
-    });
     for (const b of buttons) {
       const li = L.DomUtil.create("li", "wasabee-subactions", container);
       this._createButton({
@@ -378,21 +329,7 @@ export const WButton = L.Class.extend({
         context: b.context,
         className: "wasabee-subactions",
       });
-      L.DomEvent.on(li, "touchenter", (ev) => {
-        console.log("touchenter", ev);
-      });
-      L.DomEvent.on(li, "touchleave", (ev) => {
-        console.log("touchleave", ev);
-      });
     }
     return container;
-  },
-
-  _isTouch: function () {
-    /* console.log("mobile", L.Browser.mobile);
-    console.log("touch", L.Browser.touch);
-    console.log("userLocation", window.plugin.userLocation); */
-    // if (L.Browser.mobile && L.Browser.touch) return true;
-    return false;
   },
 });

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -299,6 +299,7 @@ export const WButton = L.Class.extend({
     );
 
     if (options.text) link.innerHTML = options.text;
+    if (options.html) link.appendChild(options.html);
 
     if (options.buttonImage) {
       const img = L.DomUtil.create("img", "wasabee-actions-image", link);
@@ -323,6 +324,7 @@ export const WButton = L.Class.extend({
       this._createButton({
         title: b.title,
         text: b.text,
+        html: b.html,
         buttonImage: b.img,
         container: li,
         callback: b.callback,

--- a/src/code/link.js
+++ b/src/code/link.js
@@ -108,10 +108,9 @@ export default class WasabeeLink {
     );
     const arrow = L.DomUtil.create("span", "wasabee-link-seperator", d);
     arrow.style.color = this.getColor(operation);
-    const picker = L.DomUtil.create("input", "", arrow);
+    const picker = L.DomUtil.create("input", "hidden-color-picker", arrow);
     picker.type = "color";
     picker.value = convertColorToHex(this.getColor(operation));
-    picker.style.display = "none";
     picker.setAttribute("list", "wasabee-colors-datalist");
 
     L.DomEvent.on(arrow, "click", () => {


### PR DESCRIPTION
Makes chrome show the color picker close to its attached html element.
fix #224 (chrome only afaik)

Side effect: I dropped the pending work on touch event and clean the html event that interfers with the color picker (`click` event and stopPropagation/preventDefault).