### PR TITLE
Update .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "es2020": true
   },
   "rules": {
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "no-console": "off",
     "lines-between-class-members": ["error", "always"],
     "no-template-curly-in-string": 1,


### PR DESCRIPTION
eslint must not normalize line endings to LF, as it breaks GIT's own processing. GIT is taking care of the normalization on push an fetch

Co-Authored-By: LeJeu <64744459+le-jeu@users.noreply.github.com>