### PR TITLE
improve firebase announcements

### DIFF
--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -104,7 +104,7 @@ const AssignDialog = WDialog.extend({
     const alreadyAdded = new Array();
 
     menu.addEventListener("change", (value) => {
-      this.localAssign(value);
+      this._assign(value);
     });
 
     const me = await WasabeeMe.waitGet();
@@ -132,7 +132,7 @@ const AssignDialog = WDialog.extend({
     return container;
   },
 
-  localAssign: function (value) {
+  _assign: function (value) {
     const operation = getSelectedOperation();
     if (this._type == "Marker") {
       operation.assignMarker(this._targetID, value.srcElement.value);

--- a/src/code/link.js
+++ b/src/code/link.js
@@ -15,6 +15,7 @@ export default class WasabeeLink {
     this.color = obj.color ? obj.color : "main";
     this.completed = obj.completed ? !!obj.completed : false;
     this.zone = obj.zone ? Number(obj.zone) : 1;
+    this.changed == !!obj.changed;
   }
 
   // build object to serialize
@@ -29,6 +30,7 @@ export default class WasabeeLink {
       color: this.color,
       completed: !!this.completed, // !! forces a boolean value
       zone: Number(this.zone),
+      changed: !!this.changed,
     };
   }
 

--- a/src/code/marker.js
+++ b/src/code/marker.js
@@ -23,6 +23,7 @@ export default class WasabeeMarker {
     this.completedBy = obj.completedBy ? obj.completedBy : "";
     this.order = obj.order ? Number(obj.order) : 0;
     this.zone = obj.zone ? Number(obj.zone) : 1;
+    this.changed = !!obj.changed; // let the server know to send announcements
 
     this.assign(obj.assignedTo); // WAS this.assignedTo = obj.assignedTo ? obj.assignedTo : "";
     // if ._state then it came from indexeddb, otherwise from server/localStorage
@@ -43,6 +44,7 @@ export default class WasabeeMarker {
       assignedTo: this.assignedTo,
       order: Number(this.order),
       zone: Number(this.zone),
+      changed: !!this.changed,
     };
   }
 
@@ -79,9 +81,11 @@ export default class WasabeeMarker {
           break;
         }
         this._state = state;
+        this.changed = true;
         break;
       case STATE_COMPLETED:
         this._state = STATE_COMPLETED;
+        this.changed = true;
         break;
       default:
         this._state = STATE_UNASSIGNED;

--- a/src/code/operation.js
+++ b/src/code/operation.js
@@ -822,6 +822,7 @@ export default class WasabeeOp {
     for (const v of this.links) {
       if (v.ID == id) {
         v.assignedTo = gid;
+        v.changed = true;
         this.update(true);
       }
     }


### PR DESCRIPTION
Problem:

Firebase messages for link/marker assignments not sent when using the normal update method, only when using the atomic API calls. This limits the potential of the mobile client from displaying important information to the agents real-time.

Proposed solution:

Add a "changed" flags to markers and links in the op JSON.
Wasabee-IITC will set this flag when a state change that needs a FB announcement is sent.
Server will look for these flags and send announcements if appropriate.