### PR TITLE
agent name, intel, rocks and V

### DIFF
--- a/src/code/css/wasabee.css
+++ b/src/code/css/wasabee.css
@@ -52,6 +52,14 @@
 }
 // .wasabee-table td.menu { position: relative; min-height: 20px; min-width: 24px; }
 
+.wasabee-dialog-agent ul {
+  padding-left: 0;
+}
+
+.wasabee-dialog-agent li {
+  list-style: none;
+}
+
 /* defined in agent.js, always on an <a> -- can this be pruned ? */
 .wasabee-agent-label a {
   text-shadow: 1px 1px #000, 1px -1px #000, -1px 1px #000, -1px -1px #000,

--- a/src/code/dialogs/agentDialog.js
+++ b/src/code/dialogs/agentDialog.js
@@ -18,23 +18,31 @@ const AgentDialog = WDialog.extend({
 
   _displayDialog: async function () {
     const html = L.DomUtil.create("div", null);
-    const agent = L.DomUtil.create("div", null, html);
 
     try {
       const data = await WasabeeAgent.get(this.options.gid);
-      const name = L.DomUtil.create("h2", "enl, wasabee-agent-label", agent);
-      name.textContent = data.name;
-      const vLabel = L.DomUtil.create("label", null, agent);
-      vLabel.textContent = "V Verified: ";
-      L.DomUtil.create("div", null, vLabel).textContent = data.Vverified;
-      const rocksLabel = L.DomUtil.create("label", null, agent);
-      rocksLabel.textContent = "Rocks Verified: ";
-      L.DomUtil.create("div", null, rocksLabel).textContent = data.rocks;
-      const img = L.DomUtil.create("img", null, agent);
+      L.DomUtil.create("h2", "wasabee-agent-label", html).textContent =
+        data.getName();
+
+      const ul = L.DomUtil.create("ul", "", html);
+      const rows = [
+        ["Server name: ", data.name],
+        ["V name: ", data.vname],
+        ["V verified: ", data.Vverified],
+        ["Rocks name: ", data.rocksname],
+        ["Rocks Verified: ", data.rocks],
+      ];
+      for (const [label, value] of rows) {
+        const li = L.DomUtil.create("li", "", ul);
+        L.DomUtil.create("label", null, li).textContent = label;
+        L.DomUtil.create("span", null, li).textContent = value;
+      }
+
+      const img = L.DomUtil.create("img", null, html);
       img.src = data.pic;
     } catch (e) {
       console.error(e);
-      agent.innerHTML = e.toString();
+      html.innerHTML = e.toString();
     }
 
     const buttons = {};

--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -128,7 +128,7 @@ const AssignDialog = WDialog.extend({
             alreadyAdded.push(a.id);
             option = L.DomUtil.create("option");
             option.value = a.id;
-            option.textContent = a.name;
+            option.textContent = a.getName();
             if (a.id == current) option.selected = true;
             menu.appendChild(option);
           }

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -212,7 +212,7 @@ const OperationChecklistDialog = WDialog.extend({
         value: async (thing) => {
           if (thing.assignedTo != null && thing.assignedTo != "") {
             const agent = await WasabeeAgent.get(thing.assignedTo);
-            if (agent != null) return agent.name;
+            if (agent != null) return agent.getName();
             return "GID: [" + thing.assignedTo + "]";
           }
           return ". . .";

--- a/src/code/dialogs/keyListPortal.js
+++ b/src/code/dialogs/keyListPortal.js
@@ -81,7 +81,7 @@ const KeyListPortal = WDialog.extend({
         sort: (a, b) => a.localeCompare(b),
         format: async (cell, value, key) => {
           const agent = await WasabeeAgent.get(key.gid);
-          cell.textContent = agent ? agent.name : key.gid;
+          cell.textContent = agent ? agent.getName() : key.gid;
         },
       },
       {

--- a/src/code/dialogs/manageTeamDialog.js
+++ b/src/code/dialogs/manageTeamDialog.js
@@ -47,12 +47,10 @@ const ManageTeamDialog = WDialog.extend({
     table.fields = [
       {
         name: wX("AGENT"),
-        value: (agent) => agent.name,
+        value: (agent) => agent.getName(),
         sort: (a, b) => a.localeCompare(b),
-        format: async (cell, value, agent) =>
-          cell.appendChild(
-            await AgentUI.formatDisplay(agent, this.options.team.id)
-          ),
+        format: (cell, value, agent) =>
+          cell.appendChild(AgentUI.formatDisplay(agent)),
       },
       {
         name: wX("TEAM STATE"),

--- a/src/code/dialogs/markerAddDialog.js
+++ b/src/code/dialogs/markerAddDialog.js
@@ -182,7 +182,7 @@ const MarkerAddDialog = WDialog.extend({
             alreadyAdded.add(a.id);
             option = L.DomUtil.create("option");
             option.value = a.id;
-            option.textContent = a.name;
+            option.textContent = a.getName();
             menu.appendChild(option);
           }
         }

--- a/src/code/dialogs/onlineAgentList.js
+++ b/src/code/dialogs/onlineAgentList.js
@@ -45,10 +45,10 @@ const OnlineAgentList = WDialog.extend({
     this._table.fields = [
       {
         name: wX("AGENT"),
-        value: (agent) => agent.name,
+        value: (agent) => agent.getName(),
         sort: (a, b) => a.localeCompare(b),
-        format: async (cell, value, agent) =>
-          cell.appendChild(await AgentUI.formatDisplay(agent)),
+        format: (cell, value, agent) =>
+          cell.appendChild(AgentUI.formatDisplay(agent)),
       },
       {
         name: "Last Seen",

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -281,8 +281,8 @@ const OpsDialog = WDialog.extend({
       };
       if (sum.currentserver) {
         const agent = await WasabeeAgent.get(tmpOp.creator);
-        sum.owner = agent.name;
-        sum.ownerDisplay = await AgentUI.formatDisplay(agent);
+        sum.owner = agent.getName();
+        sum.ownerDisplay = AgentUI.formatDisplay(agent);
       } else {
         sum.owner = window.PLAYER.nickname;
       }

--- a/src/code/dialogs/sendTargetDialog.js
+++ b/src/code/dialogs/sendTargetDialog.js
@@ -106,7 +106,7 @@ const SendTargetDialog = WDialog.extend({
             alreadyAdded.push(a.id);
             option = L.DomUtil.create("option");
             option.value = a.id;
-            option.textContent = a.name;
+            option.textContent = a.getName();
             if (a.id == current) option.selected = true;
             menu.appendChild(option);
           }

--- a/src/code/dialogs/teamMembershipList.js
+++ b/src/code/dialogs/teamMembershipList.js
@@ -53,12 +53,10 @@ const TeamMembershipList = WDialog.extend({
     table.fields = [
       {
         name: wX("AGENT"),
-        value: (agent) => agent.name,
+        value: (agent) => agent.getName(),
         sort: (a, b) => a.localeCompare(b),
-        format: async (cell, value, agent) =>
-          cell.appendChild(
-            await AgentUI.formatDisplay(agent, this.options.teamID)
-          ),
+        format: (cell, value, agent) =>
+          cell.appendChild(AgentUI.formatDisplay(agent)),
       },
       {
         name: wX("SQUAD"),

--- a/src/code/model/agent.js
+++ b/src/code/model/agent.js
@@ -20,7 +20,7 @@ export default class WasabeeAgent {
     this.name = obj.name;
     this.vname = obj.vname;
     this.rocksname = obj.rocksname;
-    this.intelname = obj.intelname;
+    this.intelname = obj.intelname !== "unset" ? obj.intelname : null;
     this.intelfaction = obj.intelfaction;
     this.level = obj.level ? Number(obj.level) : 0;
     this.enlid = obj.enlid ? obj.enlid : null;
@@ -53,6 +53,14 @@ export default class WasabeeAgent {
     this._updateCache();
   }
 
+  getName() {
+    if (this.Vverified && this.vname) return this.vname;
+    if (this.rocks && this.rocksname) return this.rocksname;
+    if (this.intelname) return this.intelname;
+    return this.name;
+  }
+
+  // deprecated
   async getTeamName(teamID = 0) {
     if (teamID == 0) return this.name;
 

--- a/src/code/ui/marker.js
+++ b/src/code/ui/marker.js
@@ -107,7 +107,7 @@ const WLMarker = PortalUI.WLPortal.extend({
       try {
         const a = await WasabeeAgent.get(marker.assignedTo);
         assignment.textContent = wX("ASS_TO"); // FIXME convert formatDisplay to html and add as value to wX
-        if (a) assignment.appendChild(await AgentUI.formatDisplay(a));
+        if (a) assignment.appendChild(AgentUI.formatDisplay(a));
         else assignment.textContent += " " + marker.assignedTo;
       } catch (err) {
         console.error(err);
@@ -117,7 +117,7 @@ const WLMarker = PortalUI.WLPortal.extend({
       try {
         const a = await WasabeeAgent.get(marker.completedID);
         assignment.innerHTML = wX("COMPLETED BY", {
-          agentName: a ? a.name : marker.completedID,
+          agentName: a ? a.getName() : marker.completedID,
         });
       } catch (e) {
         console.error(e);

--- a/src/code/wd.js
+++ b/src/code/wd.js
@@ -155,7 +155,7 @@ async function getMarkerPopup(PortalID) {
     const a = await WasabeeAgent.get(dk.GID);
     const li = L.DomUtil.create("li", null, ul);
     if (a) {
-      li.appendChild(await AgentUI.formatDisplay(a));
+      li.appendChild(AgentUI.formatDisplay(a));
     } else {
       const fake = L.DomUtil.create("span", null, li);
       fake.textContent = wX("LOADING");


### PR DESCRIPTION
We removed the use of custom agent team name (being confusing when there are multiple names for a single agent).
Suggestion is to only use the name from intel or auth tools.

If V or rocks give a name, use `.name` (should match one of those)
else If we have a name from intel, use it
otherwise, we don't have any information to name the agent, so "UnverifiedAgent" should be display (in `.name`)

To display an agent name, tell the user where the displayed name is from, and on which tool it's verified.