### PR TITLE
Remember sort column and direction for links, ops, markers and checklist

### DIFF
--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -55,23 +55,10 @@ const OperationChecklistDialog = WDialog.extend({
     const operation = getSelectedOperation();
     loadFaked(operation);
 
-    // defaults to sorting by op order
-    if (localStorage[this.SORTBY_KEY] == null) {
-      localStorage[this.SORTBY_KEY] = 0;
-    }
-    if (localStorage[this.SORTASC_KEY] == null) {
-      localStorage[this.SORTASC_KEY] = "true";
-    }
-
     this.sortable = this.getListDialogContent(
       operation,
-      operation.links.concat(operation.markers),
-      localStorage[this.SORTBY_KEY],
-      localStorage[this.SORTASC_KEY] == "true"
+      operation.links.concat(operation.markers)
     );
-
-    this.sortable.sortByStoreKey = this.SORTBY_KEY;
-    this.sortable.sortAscStoreKey = this.SORTASC_KEY;
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -108,9 +95,7 @@ const OperationChecklistDialog = WDialog.extend({
     this.setTitle(wX("OP_CHECKLIST", { opName: operation.name }));
     this.sortable = this.getListDialogContent(
       operation,
-      operation.links.concat(operation.markers),
-      localStorage[this.SORTBY_KEY],
-      localStorage[this.SORTASC_KEY] == "true"
+      operation.links.concat(operation.markers)
     );
 
     await this.sortable.done;
@@ -311,10 +296,10 @@ const OperationChecklistDialog = WDialog.extend({
     return columns;
   },
 
-  getListDialogContent: function (operation, items, sortBy, sortAsc) {
+  getListDialogContent: function (operation, items) {
     const content = new Sortable();
-    content.sortBy = sortBy; // Need to set sortBy/Asc before fields are set so column header gets sort triangle css class
-    content.sortAsc = sortAsc;
+    content.sortByStoreKey = this.SORTBY_KEY;
+    content.sortAscStoreKey = this.SORTASC_KEY;
     content.fields = this.getFields(operation);
     content.items = items;
     return content;

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -26,6 +26,9 @@ const OperationChecklistDialog = WDialog.extend({
     TYPE: "operationChecklist",
   },
 
+  SORTBY_KEY: "wasabee-checklist-sortby",
+  SORTASC_KEY: "wasabee-checklist-sortasc",
+
   options: {
     usePane: true,
   },
@@ -51,12 +54,24 @@ const OperationChecklistDialog = WDialog.extend({
   _displayDialog: async function () {
     const operation = getSelectedOperation();
     loadFaked(operation);
+
+    // defaults to sorting by op order
+    if (localStorage[this.SORTBY_KEY] == null) {
+      localStorage[this.SORTBY_KEY] = 0;
+    }
+    if (localStorage[this.SORTASC_KEY] == null) {
+      localStorage[this.SORTASC_KEY] = "true";
+    }
+
     this.sortable = this.getListDialogContent(
       operation,
       operation.links.concat(operation.markers),
-      0,
-      false
-    ); // defaults to sorting by op order
+      localStorage[this.SORTBY_KEY],
+      localStorage[this.SORTASC_KEY] == "true"
+    );
+
+    this.sortable.sortByStoreKey = this.SORTBY_KEY;
+    this.sortable.sortAscStoreKey = this.SORTASC_KEY;
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -94,9 +109,10 @@ const OperationChecklistDialog = WDialog.extend({
     this.sortable = this.getListDialogContent(
       operation,
       operation.links.concat(operation.markers),
-      this.sortable.sortBy,
-      this.sortable.sortAsc
+      localStorage[this.SORTBY_KEY],
+      localStorage[this.SORTASC_KEY] == "true"
     );
+
     await this.sortable.done;
     this.setContent(this.sortable.table);
   },
@@ -297,9 +313,9 @@ const OperationChecklistDialog = WDialog.extend({
 
   getListDialogContent: function (operation, items, sortBy, sortAsc) {
     const content = new Sortable();
-    content.fields = this.getFields(operation);
-    content.sortBy = sortBy;
+    content.sortBy = sortBy; // Need to set sortBy/Asc before fields are set so column header gets sort triangle css class
     content.sortAsc = sortAsc;
+    content.fields = this.getFields(operation);
     content.items = items;
     return content;
   },

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -45,7 +45,7 @@ const KeysList = WDialog.extend({
 
     this.createDialog({
       title: wX("KEY_LIST2", { opName: operation.name }),
-      html: this.getListDialogContent(operation, 0, false).table,
+      html: this.getListDialogContent(operation, 0, true).table,
       width: "auto",
       dialogClass: "keyslist",
       buttons: buttons,

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -11,6 +11,9 @@ const LinkListDialog = OperationChecklistDialog.extend({
     TYPE: "linkListDialog",
   },
 
+  SORTBY_KEY: "wasabee-linklist-sortby",
+  SORTASC_KEY: "wasabee-linklist-sortasc",
+
   options: {
     usePane: true,
     // portal
@@ -54,7 +57,21 @@ const LinkListDialog = OperationChecklistDialog.extend({
     ).length;
     const toCount = links.length - fromCount;
 
-    this.sortable = this.getListDialogContent(operation, links, 0, false); // defaults to sorting by op order
+    if (localStorage[this.SORTBY_KEY] == null) {
+      localStorage[this.SORTBY_KEY] = 0;
+    }
+    if (localStorage[this.SORTASC_KEY] == null) {
+      localStorage[this.SORTASC_KEY] = "true";
+    }
+    this.sortable = this.getListDialogContent(
+      operation,
+      links,
+      localStorage[this.SORTBY_KEY],
+      localStorage[this.SORTASC_KEY] == "true"
+    );
+
+    this.sortable.sortByStoreKey = this.SORTBY_KEY;
+    this.sortable.sortAscStoreKey = this.SORTASC_KEY;
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -88,8 +105,8 @@ const LinkListDialog = OperationChecklistDialog.extend({
     this.sortable = this.getListDialogContent(
       operation,
       links,
-      this.sortable.sortBy,
-      this.sortable.sortAsc
+      localStorage[this.SORTBY_KEY],
+      localStorage[this.SORTASC_KEY] == "true"
     );
     await this.sortable.done;
     this.setContent(this.sortable.table);

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -57,21 +57,7 @@ const LinkListDialog = OperationChecklistDialog.extend({
     ).length;
     const toCount = links.length - fromCount;
 
-    if (localStorage[this.SORTBY_KEY] == null) {
-      localStorage[this.SORTBY_KEY] = 0;
-    }
-    if (localStorage[this.SORTASC_KEY] == null) {
-      localStorage[this.SORTASC_KEY] = "true";
-    }
-    this.sortable = this.getListDialogContent(
-      operation,
-      links,
-      localStorage[this.SORTBY_KEY],
-      localStorage[this.SORTASC_KEY] == "true"
-    );
-
-    this.sortable.sortByStoreKey = this.SORTBY_KEY;
-    this.sortable.sortAscStoreKey = this.SORTASC_KEY;
+    this.sortable = this.getListDialogContent(operation, links);
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -102,12 +88,7 @@ const LinkListDialog = OperationChecklistDialog.extend({
       (l) => l.fromPortalId == this.options.portal.id
     ).length;
     const toCount = links.length - fromCount;
-    this.sortable = this.getListDialogContent(
-      operation,
-      links,
-      localStorage[this.SORTBY_KEY],
-      localStorage[this.SORTASC_KEY] == "true"
-    );
+    this.sortable = this.getListDialogContent(operation, links);
     await this.sortable.done;
     this.setContent(this.sortable.table);
     this.setTitle(

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -15,23 +15,7 @@ const MarkerList = OperationChecklistDialog.extend({
     const operation = getSelectedOperation();
     loadFaked(operation);
 
-    if (localStorage[this.SORTBY_KEY] == null) {
-      localStorage[this.SORTBY_KEY] = 0;
-    }
-    if (localStorage[this.SORTASC_KEY] == null) {
-      localStorage[this.SORTASC_KEY] = "true";
-    }
-
-    this.sortable = this.getListDialogContent(
-      operation,
-      operation.markers,
-      localStorage[this.SORTBY_KEY],
-      localStorage[this.SORTASC_KEY] == "true"
-    );
-
-    // where to save the column and dir when changed
-    this.sortable.sortByStoreKey = this.SORTBY_KEY;
-    this.sortable.sortAscStoreKey = this.SORTASC_KEY;
+    this.sortable = this.getListDialogContent(operation, operation.markers);
 
     const buttons = {};
     buttons[wX("CLEAR MARKERS")] = () => {
@@ -58,12 +42,7 @@ const MarkerList = OperationChecklistDialog.extend({
     if (!this.sortable) return;
     const operation = getSelectedOperation();
     this.setTitle(wX("MARKER_LIST", { opName: operation.name }));
-    this.sortable = this.getListDialogContent(
-      operation,
-      operation.markers,
-      localStorage[this.SORTBY_KEY],
-      localStorage[this.SORTASC_KEY] == "true"
-    );
+    this.sortable = this.getListDialogContent(operation, operation.markers);
     await this.sortable.done;
     this.setContent(this.sortable.table);
   },

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -8,15 +8,30 @@ const MarkerList = OperationChecklistDialog.extend({
     TYPE: "markerList",
   },
 
+  SORTBY_KEY: "wasabee-markerlist-sortby",
+  SORTASC_KEY: "wasabee-markerlist-sortasc",
+
   _displayDialog: async function () {
     const operation = getSelectedOperation();
     loadFaked(operation);
+
+    if (localStorage[this.SORTBY_KEY] == null) {
+      localStorage[this.SORTBY_KEY] = 0;
+    }
+    if (localStorage[this.SORTASC_KEY] == null) {
+      localStorage[this.SORTASC_KEY] = "true";
+    }
+
     this.sortable = this.getListDialogContent(
       operation,
       operation.markers,
-      0,
-      false
-    ); // defaults to sorting by op order
+      localStorage[this.SORTBY_KEY],
+      localStorage[this.SORTASC_KEY] == "true"
+    );
+
+    // where to save the column and dir when changed
+    this.sortable.sortByStoreKey = this.SORTBY_KEY;
+    this.sortable.sortAscStoreKey = this.SORTASC_KEY;
 
     const buttons = {};
     buttons[wX("CLEAR MARKERS")] = () => {
@@ -46,8 +61,8 @@ const MarkerList = OperationChecklistDialog.extend({
     this.sortable = this.getListDialogContent(
       operation,
       operation.markers,
-      this.sortable.sortBy,
-      this.sortable.sortAsc
+      localStorage[this.SORTBY_KEY],
+      localStorage[this.SORTASC_KEY] == "true"
     );
     await this.sortable.done;
     this.setContent(this.sortable.table);

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -49,17 +49,7 @@ const OpsDialog = WDialog.extend({
   },
 
   _displayDialog: async function () {
-    if (localStorage[this.SORTBY_KEY] == null) {
-      localStorage[this.SORTBY_KEY] = 0;
-    }
-    if (localStorage[this.SORTASC_KEY] == null) {
-      localStorage[this.SORTASC_KEY] = "true";
-    }
-
-    this.initSortable(
-      localStorage[this.SORTBY_KEY],
-      localStorage[this.SORTASC_KEY] == "true"
-    );
+    this.initSortable();
 
     await this.updateSortable();
 
@@ -100,10 +90,10 @@ const OpsDialog = WDialog.extend({
     }
   },
 
-  initSortable: function (sortBy, sortAsc) {
+  initSortable: function () {
     const content = new Sortable();
-    content.sortBy = sortBy;
-    content.sortAsc = sortAsc;
+    content.sortByStoreKey = this.SORTBY_KEY;
+    content.sortAscStoreKey = this.SORTASC_KEY;
     content.fields = [
       {
         name: "S",
@@ -265,8 +255,6 @@ const OpsDialog = WDialog.extend({
       },
     ];
     this.sortable = content;
-    this.sortable.sortByStoreKey = this.SORTBY_KEY;
-    this.sortable.sortAscStoreKey = this.SORTASC_KEY;
   },
 
   updateSortable: async function () {

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -200,17 +200,17 @@ const OpsDialog = WDialog.extend({
           const background = L.DomUtil.create("input", null, cell);
           background.type = "checkbox";
           background.checked = op.background;
-          
+
           background.title = op.background
-          ? wX("dialog.ops_list.background_disable")
-          : wX("dialog.ops_list.background_enable");
+            ? wX("dialog.ops_list.background_disable")
+            : wX("dialog.ops_list.background_enable");
           L.DomEvent.on(background, "change", (ev) => {
             L.DomEvent.stop(ev);
             const background = ev.target;
             // wX
             background.title = background.checked
-            ? wX("dialog.ops_list.background_disable")
-            : wX("dialog.ops_list.background_enable");
+              ? wX("dialog.ops_list.background_disable")
+              : wX("dialog.ops_list.background_enable");
             setOpBackground(op.id, background.checked);
           });
         },

--- a/src/code/sortable.ts
+++ b/src/code/sortable.ts
@@ -37,10 +37,11 @@ export default class Sortable<T> {
     this._sortBy = 0; // which field/column number to sort by
     this._sortAsc = true; // ascending or descending
     this._table = L.DomUtil.create("table", "wasabee-table");
-
+ 
     // create this once for all
     this._head = L.DomUtil.create("thead", null, this._table);
     this._body = L.DomUtil.create("tbody", null, this._table);
+    this._foot = L.DomUtil.create("tfoot", null, this._table);
 
     // if IITC-Mobile is detected... this is a kludge
     this._smallScreen = window.plugin.userLocation ? true : false;

--- a/src/code/sortable.ts
+++ b/src/code/sortable.ts
@@ -86,10 +86,18 @@ export default class Sortable<T> {
 
   set sortByStoreKey(b) {
     this._sortByStoreKey = b;
+    if (localStorage[this._sortByStoreKey] == null) {
+      localStorage[this._sortByStoreKey] = 0;
+    }
+    this.sortBy = localStorage[this._sortByStoreKey];
   }
 
   set sortAscStoreKey(b) {
     this._sortAscStoreKey = b;
+    if (localStorage[this._sortAscStoreKey] == null) {
+      localStorage[this._sortAscStoreKey] = "true";
+    }
+    this._sortAsc = localStorage[this._sortAscStoreKey] == "true";
   }
 
   get table() {


### PR DESCRIPTION
#109 - Persist the sortBy and sortAsc in localStorage. Also fix the sortAsc direction so that true means larger values at the end of the list. Also make the direction triangle appear when dialog is displayed. 