### PR TITLE
#338 - Handle case where same key is in multiple capsules for an agent

### DIFF
--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -177,13 +177,19 @@ const KeysList = WDialog.extend({
       if (thesekeys && thesekeys.length > 0) {
         for (const t of thesekeys) {
           k.onHand += t.onhand;
+        }
+        for (const t of thesekeys) {
           if (t.gid == gid) {
-            k.iHave = t.onhand;
-            k.capsule = t.capsule;
+            const mk = {};
+            mk.id = a;
+            mk.Required = links.length;
+            mk.onHand = k.onHand;
+            mk.iHave = t.onhand;
+            mk.capsule = t.capsule;
+            keys.push(mk);
           }
         }
-      }
-      keys.push(k);
+      } else keys.push(k);
     }
 
     for (const p of operation.markers.filter(function (marker) {
@@ -202,13 +208,19 @@ const KeysList = WDialog.extend({
       if (thesekeys && thesekeys.length > 0) {
         for (const t of thesekeys) {
           k.onHand += t.onhand;
+        }
+        for (const t of thesekeys) {
           if (t.gid == gid) {
-            k.iHave = t.onhand;
-            k.capsule = t.capsule;
+            const mk = {};
+            mk.id = p.portalId;
+            mk.Required = wX("OPEN_REQUEST");
+            mk.onHand = k.onHand;
+            mk.iHave = t.onhand;
+            mk.capsule = t.capsule;
+            keys.push(mk);
           }
         }
-      }
-      keys.push(k);
+      } else keys.push(k);
     }
 
     this.sortable.sortBy = sortBy;

--- a/src/code/model/operation.ts
+++ b/src/code/model/operation.ts
@@ -1109,11 +1109,10 @@ export default class WasabeeOp extends Evented implements IOperation {
     onhand: number,
     capsule: string
   ) {
-    capsule = onhand > 0 ? capsule : ""
     if (typeof onhand == "string") {
       onhand = Number.parseInt(onhand, 10);
     }
-
+    capsule = onhand > 0 ? capsule : ""
     for (const k of this.keysonhand) {
       // fix broken ops
       if (typeof k.onhand == "string") {

--- a/src/code/model/operation.ts
+++ b/src/code/model/operation.ts
@@ -1109,6 +1109,7 @@ export default class WasabeeOp extends Evented implements IOperation {
     onhand: number,
     capsule: string
   ) {
+    capsule = onhand > 0 ? capsule : ""
     if (typeof onhand == "string") {
       onhand = Number.parseInt(onhand, 10);
     }


### PR DESCRIPTION
For #338, this change will allow for the display of a key in multiple capsules for a single agent. Will also allow for 1) changing the capsule name, 2) changing the number of keys in the capsule, 3) no capsule name entered, and 4) if a count of 0 is entered, the capsule name is forced to be "".