### PR TITLE
Persist sortBy and sortAsc in local storage for ops, checklist, links and markers

### DIFF
--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -26,6 +26,9 @@ const OperationChecklistDialog = WDialog.extend({
     TYPE: "operationChecklist",
   },
 
+  SORTBY_KEY: "wasabee-checklist-sortby",
+  SORTASC_KEY: "wasabee-checklist-sortasc",
+
   options: {
     usePane: true,
   },
@@ -51,12 +54,13 @@ const OperationChecklistDialog = WDialog.extend({
   _displayDialog: async function () {
     const operation = getSelectedOperation();
     loadFaked(operation);
+
     this.sortable = this.getListDialogContent(
       operation,
       operation.links.concat(operation.markers),
-      0,
-      false
-    ); // defaults to sorting by op order
+      this.SORTBY_KEY,
+      this.SORTASC_KEY
+    );
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -94,9 +98,10 @@ const OperationChecklistDialog = WDialog.extend({
     this.sortable = this.getListDialogContent(
       operation,
       operation.links.concat(operation.markers),
-      this.sortable.sortBy,
-      this.sortable.sortAsc
+      this.SORTBY_KEY,
+      this.SORTASC_KEY
     );
+
     await this.sortable.done;
     this.setContent(this.sortable.table);
   },
@@ -295,11 +300,16 @@ const OperationChecklistDialog = WDialog.extend({
     return columns;
   },
 
-  getListDialogContent: function (operation, items, sortBy, sortAsc) {
+  getListDialogContent: function (
+    operation,
+    items,
+    sortByStoreKey,
+    sortAscStoreKey
+  ) {
     const content = new Sortable();
     content.fields = this.getFields(operation);
-    content.sortBy = sortBy;
-    content.sortAsc = sortAsc;
+    content.sortByStoreKey = sortByStoreKey;
+    content.sortAscStoreKey = sortAscStoreKey;
     content.items = items;
     return content;
   },

--- a/src/code/dialogs/keysList.js
+++ b/src/code/dialogs/keysList.js
@@ -45,7 +45,7 @@ const KeysList = WDialog.extend({
 
     this.createDialog({
       title: wX("KEY_LIST2", { opName: operation.name }),
-      html: this.getListDialogContent(operation, 0, false).table,
+      html: this.getListDialogContent(operation, 0, true).table,
       width: "auto",
       dialogClass: "keyslist",
       buttons: buttons,
@@ -153,7 +153,7 @@ const KeysList = WDialog.extend({
         },
       ]);
     } else {
-      this.sortable.fields = always;
+      this.sortable.fields = always; 
     }
 
     const keys = new Array();

--- a/src/code/dialogs/linkListDialog.js
+++ b/src/code/dialogs/linkListDialog.js
@@ -11,6 +11,9 @@ const LinkListDialog = OperationChecklistDialog.extend({
     TYPE: "linkListDialog",
   },
 
+  SORTBY_KEY: "wasabee-linklist-sortby",
+  SORTASC_KEY: "wasabee-linklist-sortasc",
+
   options: {
     usePane: true,
     // portal
@@ -54,7 +57,12 @@ const LinkListDialog = OperationChecklistDialog.extend({
     ).length;
     const toCount = links.length - fromCount;
 
-    this.sortable = this.getListDialogContent(operation, links, 0, false); // defaults to sorting by op order
+    this.sortable = this.getListDialogContent(
+      operation,
+      links,
+      this.SORTBY_KEY,
+      this.SORTASC_KEY
+    );
 
     const buttons = {};
     buttons[wX("OK")] = () => {
@@ -88,8 +96,8 @@ const LinkListDialog = OperationChecklistDialog.extend({
     this.sortable = this.getListDialogContent(
       operation,
       links,
-      this.sortable.sortBy,
-      this.sortable.sortAsc
+      this.SORTBY_KEY,
+      this.SORTASC_KEY
     );
     await this.sortable.done;
     this.setContent(this.sortable.table);

--- a/src/code/dialogs/markerList.js
+++ b/src/code/dialogs/markerList.js
@@ -8,15 +8,19 @@ const MarkerList = OperationChecklistDialog.extend({
     TYPE: "markerList",
   },
 
+  SORTBY_KEY: "wasabee-markerlist-sortby",
+  SORTASC_KEY: "wasabee-markerlist-sortasc",
+
   _displayDialog: async function () {
     const operation = getSelectedOperation();
     loadFaked(operation);
+
     this.sortable = this.getListDialogContent(
       operation,
       operation.markers,
-      0,
-      false
-    ); // defaults to sorting by op order
+      this.SORTBY_KEY,
+      this.SORTASC_KEY
+    );
 
     const buttons = {};
     buttons[wX("CLEAR MARKERS")] = () => {
@@ -46,8 +50,8 @@ const MarkerList = OperationChecklistDialog.extend({
     this.sortable = this.getListDialogContent(
       operation,
       operation.markers,
-      this.sortable.sortBy,
-      this.sortable.sortAsc
+      this.SORTBY_KEY,
+      this.SORTASC_KEY
     );
     await this.sortable.done;
     this.setContent(this.sortable.table);

--- a/src/code/dialogs/opsDialog.js
+++ b/src/code/dialogs/opsDialog.js
@@ -24,6 +24,9 @@ const OpsDialog = WDialog.extend({
     TYPE: "opsDialog",
   },
 
+  SORTBY_KEY: "wasabee-opslist-sortby",
+  SORTASC_KEY: "wasabee-opslist-sortasc",
+
   options: {
     usePane: true,
   },
@@ -47,9 +50,11 @@ const OpsDialog = WDialog.extend({
 
   _displayDialog: async function () {
     this.initSortable();
-    await this.updateSortable(0, false);
+
+    await this.updateSortable();
 
     const buttons = {};
+    // wX
     buttons[wX("dialog.ops_list.unhide_ops")] = () => {
       resetHiddenOps();
       this.update();
@@ -80,7 +85,7 @@ const OpsDialog = WDialog.extend({
 
   update: async function () {
     if (this._enabled) {
-      await this.updateSortable(this.sortable.sortBy, this.sortable.sortAsc);
+      await this.updateSortable();
       // this.setContent(this.sortable.table);
     }
   },
@@ -183,12 +188,14 @@ const OpsDialog = WDialog.extend({
           const background = L.DomUtil.create("input", null, cell);
           background.type = "checkbox";
           background.checked = op.background;
+
           background.title = op.background
             ? wX("dialog.ops_list.background_disable")
             : wX("dialog.ops_list.background_enable");
           L.DomEvent.on(background, "change", (ev) => {
             L.DomEvent.stop(ev);
             const background = ev.target;
+            // wX
             background.title = background.checked
               ? wX("dialog.ops_list.background_disable")
               : wX("dialog.ops_list.background_enable");
@@ -245,10 +252,12 @@ const OpsDialog = WDialog.extend({
         },
       },
     ];
+    content.sortByStoreKey = this.SORTBY_KEY;
+    content.sortAscStoreKey = this.SORTASC_KEY;
     this.sortable = content;
   },
 
-  updateSortable: async function (sortBy, sortAsc) {
+  updateSortable: async function () {
     if (!this.sortable) return;
     // collapse markers and links into one array.
     const showHiddenOps =
@@ -294,8 +303,7 @@ const OpsDialog = WDialog.extend({
       }
       ops.push(sum);
     }
-    this.sortable.sortBy = sortBy;
-    this.sortable.sortAsc = sortAsc;
+
     this.sortable.items = ops;
     await this.sortable.done;
 

--- a/src/code/sortable.ts
+++ b/src/code/sortable.ts
@@ -99,7 +99,7 @@ export default class Sortable<T> {
     if (localStorage[this._sortAscStoreKey] == null) {
       localStorage[this._sortAscStoreKey] = "true";
     }
-    this._sortAsc = localStorage[this._sortAscStoreKey] == "true";
+    this.sortAsc = localStorage[this._sortAscStoreKey] == "true";
   }
 
   get table() {

--- a/src/code/sortable.ts
+++ b/src/code/sortable.ts
@@ -28,14 +28,16 @@ export default class Sortable<T> {
   _foot: HTMLTableSectionElement;
   _smallScreen: boolean;
   _done: Promise<boolean | void> | boolean;
+  _sortByStoreKey: string;
+  _sortAscStoreKey: string;
 
   constructor() {
     this._items = [];
     this._fields = [];
     this._sortBy = 0; // which field/column number to sort by
-    this._sortAsc = false; // ascending or descending
+    this._sortAsc = true; // ascending or descending
     this._table = L.DomUtil.create("table", "wasabee-table");
-
+ 
     // create this once for all
     this._head = L.DomUtil.create("thead", null, this._table);
     this._body = L.DomUtil.create("tbody", null, this._table);
@@ -43,7 +45,8 @@ export default class Sortable<T> {
 
     // if IITC-Mobile is detected... this is a kludge
     this._smallScreen = window.plugin.userLocation ? true : false;
-
+    this._sortByStoreKey = "";
+    this._sortAscStoreKey = "";
     this._done = true;
   }
 
@@ -68,6 +71,7 @@ export default class Sortable<T> {
 
   set sortBy(property) {
     this._sortBy = Number(property);
+    this.renderHead();
     this.sort();
   }
 
@@ -78,7 +82,24 @@ export default class Sortable<T> {
   set sortAsc(b) {
     if (b !== true) b = false;
     this._sortAsc = b;
+    this.renderHead();
     this.sort();
+  }
+
+  set sortByStoreKey(b) {
+    this._sortByStoreKey = b;
+    if (localStorage[this._sortByStoreKey] == null) {
+      localStorage[this._sortByStoreKey] = 0;
+    }
+    this.sortBy = localStorage[this._sortByStoreKey];
+  }
+
+  set sortAscStoreKey(b) {
+    this._sortAscStoreKey = b;
+    if (localStorage[this._sortAscStoreKey] == null) {
+      localStorage[this._sortAscStoreKey] = "true";
+    }
+    this._sortAsc = localStorage[this._sortAscStoreKey] == "true";
   }
 
   get table() {
@@ -189,22 +210,26 @@ export default class Sortable<T> {
         cell.style.display = "none";
       if (field.sort !== null) {
         L.DomUtil.addClass(cell, "sortable");
+        if (index == this._sortBy) {
+          L.DomUtil.addClass(cell, this._sortAsc ? "asc" : "desc");
+        }
         L.DomEvent.on(
           cell,
           "click",
           (ev) => {
             L.DomEvent.stop(ev);
             for (const element of titleRow.children) {
-              L.DomUtil.removeClass(element as HTMLElement, "sorted");
               L.DomUtil.removeClass(element as HTMLElement, "asc");
               L.DomUtil.removeClass(element as HTMLElement, "desc");
             }
             if (index == this._sortBy) {
               this._sortAsc = !this._sortAsc;
-              L.DomUtil.addClass(cell, "sorted");
-              L.DomUtil.addClass(cell, this._sortAsc ? "asc" : "desc");
             }
+            L.DomUtil.addClass(cell, this._sortAsc ? "asc" : "desc");
+            
             this._sortBy = index;
+            if (this._sortByStoreKey != null) localStorage[this._sortByStoreKey] = this._sortBy;
+            if (this._sortAscStoreKey != null) localStorage[this._sortAscStoreKey] = this._sortAsc.toString();
             this.sort();
           },
           false
@@ -246,7 +271,7 @@ export default class Sortable<T> {
       }
       // if two values are the same, preserve previous order
       if (l == 0) l = a.index - b.index;
-      return this._sortAsc ? -l : l;
+      return this._sortAsc ? l : -l;
     });
 
     for (const [index, item] of this._items.entries()) {


### PR DESCRIPTION
#109 - The previous PR did not set sortAsc in sortable when sortAscStoreKey is set. By doing it this way, the re-sort is forced based on the sortAscStoreKey value.