### PR TITLE
Live location while iitc is foreground

### DIFF
--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -79,13 +79,6 @@ const SettingsDialog = WDialog.extend({
       }
     );
 
-    this._addCheckBox(
-      container,
-      wX("SEND LOCATION"),
-      "wasabee-setting-sendloc",
-      window.plugin.wasabee.static.constants.SEND_LOCATION_KEY
-    );
-
     this._addSelect(
       container,
       wX("SKIP_CONFIRM"),
@@ -97,12 +90,15 @@ const SettingsDialog = WDialog.extend({
       ]
     );
 
-    this._addCheckBox(
-      container,
-      wX("SEND ANALYTICS"),
-      "wasabee-setting-analytics",
-      window.plugin.wasabee.static.constants.SEND_ANALYTICS_KEY
-    );
+    // send location on mobile
+    if (window.plugin.userLocation) {
+      this._addCheckBox(
+        container,
+        wX("SEND LOCATION"),
+        "wasabee-setting-sendloc",
+        window.plugin.wasabee.static.constants.SEND_LOCATION_KEY
+      );
+    }
 
     this._addCheckBox(
       container,
@@ -120,6 +116,22 @@ const SettingsDialog = WDialog.extend({
       window.plugin.wasabee.static.constants.AUTO_LOAD_FAKED
     );
 
+    if (window.isSmartphone()) {
+      this._addCheckBox(
+        container,
+        wX("USE PANES ON MOBILE"),
+        "wasabee-setting-usepanes",
+        window.plugin.wasabee.static.constants.USE_PANES
+      );
+    }
+
+    this._addCheckBox(
+      container,
+      wX("SEND ANALYTICS"),
+      "wasabee-setting-analytics",
+      window.plugin.wasabee.static.constants.SEND_ANALYTICS_KEY
+    );
+
     this._addSelect(
       container,
       wX("AUTOLOAD_RATE"),
@@ -133,15 +145,6 @@ const SettingsDialog = WDialog.extend({
       window.plugin.wasabee.static.constants.TRAWL_SKIP_STEPS,
       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14].map((v) => [v, v])
     );
-
-    if (window.isSmartphone()) {
-      this._addCheckBox(
-        container,
-        wX("USE PANES ON MOBILE"),
-        "wasabee-setting-usepanes",
-        window.plugin.wasabee.static.constants.USE_PANES
-      );
-    }
 
     const serverInfo = L.DomUtil.create("button", "server", container);
     serverInfo.textContent = wX("WSERVER", { url: GetWasabeeServer() });

--- a/src/code/translations/English.json
+++ b/src/code/translations/English.json
@@ -384,7 +384,7 @@
   "SELECT_ONION_PORTALS": "Layers build from the inside out. Zoom in to center and select starting portal, then zoom out to area.",
   "SELF SWAP": "Cannot swap a portal with itself! Select a different portal.",
   "SEND ANALYTICS": "Send Anonymous Analytics",
-  "SEND LOCATION": "Send Location",
+  "SEND LOCATION": "Share Location (only when IITC is in foreground)",
   "SEND TARGET AGENT": "Select target recipient",
   "SEND TARGET CONFIRM": "Do you want to send {portalName} target to {agent}?",
   "SEND TARGET": "Send Target",

--- a/src/types/iitc/core/hooks.d.ts
+++ b/src/types/iitc/core/hooks.d.ts
@@ -177,6 +177,15 @@ declare global {
 
   /**
    * register a callback for an event
+   * called when the user location or orientation changed.
+   */
+  function addHook(
+    event: "pluginUserLocation",
+    callback: (e: EventUserLocation) => void
+  ): void;
+
+  /**
+   * register a callback for an event
    * (user defined hooks)
    */
   function addHook(event: string, callback: HookCallback): void;
@@ -276,4 +285,9 @@ declare global {
         ent: PortalDetailEnt;
       }
     | { guid: string; success: false; details: never; ent: never };
+
+  interface EventUserLocation {
+    event: "setup" | "onLocationChange" | "onOrientationChange";
+    data: { latlng: L.LatLng; direction: number };
+  }
 }


### PR DESCRIPTION
clarification + regular location update (from IITC mobile) instead of :

> Currently, the iitc plugin sends a location on rare occasion :
>   - the user press the button "Send location" from the iitc toolbox
>   - on login if the user enabled "Send location" in (local) settings
>   - on iitc resume (when the user switch back to the IITC app) and they enabled the "Send location" in (local) settings

fix #297 