### PR TITLE
[Feature] Undo/redo recent changes

### DIFF
--- a/src/code/buttons/opButton.js
+++ b/src/code/buttons/opButton.js
@@ -5,6 +5,7 @@ import OperationChecklistDialog from "../dialogs/checklist";
 import KeysList from "../dialogs/keysList";
 import wX from "../wX";
 import { redo, redoable, undo, undoable } from "../undo";
+import { postToFirebase } from "../firebase/logger";
 
 const OpButton = WButton.extend({
   statics: {
@@ -89,6 +90,7 @@ const OpButton = WButton.extend({
         text: wX("toolbar.op.undo"),
         accesskey: "z",
         callback: () => {
+          postToFirebase({ id: "analytics", action: "undo" });
           undo();
         },
         context: this,
@@ -101,6 +103,7 @@ const OpButton = WButton.extend({
         text: wX("toolbar.op.redo"),
         accesskey: "y",
         callback: () => {
+          postToFirebase({ id: "analytics", action: "redo" });
           redo();
         },
         context: this,

--- a/src/code/buttons/opButton.js
+++ b/src/code/buttons/opButton.js
@@ -87,6 +87,7 @@ const OpButton = WButton.extend({
       actions.push({
         title: wX("toolbar.op.undo"),
         text: wX("toolbar.op.undo"),
+        accesskey: "z",
         callback: () => {
           undo();
         },
@@ -98,6 +99,7 @@ const OpButton = WButton.extend({
       actions.push({
         title: wX("toolbar.op.redo"),
         text: wX("toolbar.op.redo"),
+        accesskey: "y",
         callback: () => {
           redo();
         },

--- a/src/code/buttons/opButton.js
+++ b/src/code/buttons/opButton.js
@@ -4,6 +4,7 @@ import BlockersList from "../dialogs/blockersList";
 import OperationChecklistDialog from "../dialogs/checklist";
 import KeysList from "../dialogs/keysList";
 import wX from "../wX";
+import { redo, redoable, undo, undoable } from "../undo";
 
 const OpButton = WButton.extend({
   statics: {
@@ -32,8 +33,14 @@ const OpButton = WButton.extend({
     });
   },
 
+  update: function () {
+    WButton.prototype.update.call(this);
+    this.button.title = wX("OP_BUTTON");
+    this.setSubActions(this.getSubActions());
+  },
+
   getSubActions: function () {
-    return [
+    const actions = [
       {
         title: wX("OP_SETTINGS_TITLE"),
         text: wX("OP_SETTINGS_BUTTON"),
@@ -75,6 +82,30 @@ const OpButton = WButton.extend({
         context: this,
       },
     ];
+
+    if (undoable()) {
+      actions.push({
+        title: wX("toolbar.op.undo"),
+        text: wX("toolbar.op.undo"),
+        callback: () => {
+          undo();
+        },
+        context: this,
+      });
+    }
+
+    if (redoable()) {
+      actions.push({
+        title: wX("toolbar.op.redo"),
+        text: wX("toolbar.op.redo"),
+        callback: () => {
+          redo();
+        },
+        context: this,
+      });
+    }
+
+    return actions;
   },
 
   // enable: // default is good

--- a/src/code/init.ts
+++ b/src/code/init.ts
@@ -31,6 +31,7 @@ import { deleteJWT } from "./auth";
 import { checkVersion } from "./version";
 import wX from "./wX";
 import { getMe } from "./model/cache";
+import { initHistory } from "./undo";
 
 import type { FeatureGroup, LayerEvent, LayerGroup } from "leaflet";
 import type { WLAnchor, WLAgent, WLLink, WLMarker, WLZone } from "./map";
@@ -236,6 +237,9 @@ window.plugin.wasabee.init = async () => {
   if (sl !== "true") {
     localStorage[Wasabee.static.constants.SEND_LOCATION_KEY] = "false";
   }
+
+  // setup undo
+  initHistory();
 
   // setup UI elements
   addButtons();

--- a/src/code/leafletClasses.d.ts
+++ b/src/code/leafletClasses.d.ts
@@ -73,6 +73,7 @@ export declare type ButtonOptions = {
   buttonImage?: string;
   className?: string;
   img?: string;
+  accesskey?: string;
 };
 export declare class WButton extends L.Class {
   title: string;

--- a/src/code/leafletClasses.js
+++ b/src/code/leafletClasses.js
@@ -387,6 +387,7 @@ export const WButton = L.Class.extend({
 
     if (options.text) link.innerHTML = options.text;
     if (options.html) link.appendChild(options.html);
+    if (options.accesskey) link.accessKey = options.accesskey;
 
     if (options.buttonImage) {
       const img = L.DomUtil.create("img", "wasabee-actions-image", link);

--- a/src/code/static.ts
+++ b/src/code/static.ts
@@ -104,6 +104,7 @@ const statics: Statics = {
     JOIN_TEAM_TEMPLATE:
       "https://webui.wasabee.rocks/?server={server}#/team/{teamid}/join/{token}",
     FIREBASE_IFRAME: "https://cdn2.wasabee.rocks/iitcplugin/firebase/",
+    UNDO_HISTORY_SIZE: 100,
   },
   publicServers: [
     { name: "Americas", url: "https://am.wasabee.rocks", short: "🇺🇸" },

--- a/src/code/translations/English.json
+++ b/src/code/translations/English.json
@@ -432,6 +432,8 @@
   "TEAMS BUTTON TITLE": "List Wasabee Teams",
   "TEAMS BUTTON": "Teams",
   "TO_PORT": "To Portal",
+  "toolbar.op.redo": "Redo",
+  "toolbar.op.undo": "Undo",
   "toolbar.quick_delete.apply.text": "Apply",
   "toolbar.quick_delete.apply.title": "Delete selected links/markers",
   "toolbar.quick_delete.cancel.text": "Cancel",

--- a/src/code/undo.ts
+++ b/src/code/undo.ts
@@ -1,0 +1,80 @@
+import { WasabeeOp } from "./model";
+import { getSelectedOperation, makeSelectedOperation } from "./selectedOp";
+import { constants } from "./static";
+
+// contains the stack of versions, last element is a copy of the current version
+let undo_list: Promise<WasabeeOp>[] = [];
+// stack of undone versions
+let redo_list: Promise<WasabeeOp>[] = [];
+let undoing = false; // lock
+
+export function initHistory() {
+  onSelect();
+  window.map.on("wasabee:op:change", onChange);
+  window.map.on("wasabee:op:select", onSelect);
+}
+
+function onSelect() {
+  // empty the undo list on op select
+  const sop = getSelectedOperation();
+  undo_list = [WasabeeOp.load(sop.ID)];
+  redo_list = [];
+}
+
+export async function undo() {
+  if (undo_list.length < 2) {
+    // nothing to undo
+    return false;
+  }
+  const sop = getSelectedOperation();
+  // move current version to undone list
+  redo_list.push(undo_list.pop());
+
+  undoing = true;
+  const op = await undo_list[undo_list.length-1];
+  // use last server-related attributes
+  op.fetched = sop.fetched;
+  op.fetchedOp = sop.fetchedOp;
+  op.lasteditid = sop.lasteditid;
+  await op.store();
+  // switch to this op
+  await makeSelectedOperation(op.ID);
+  undoing = false;
+  return true;
+}
+
+export async function redo() {
+  if (!redo_list.length) return false;
+  const sop = getSelectedOperation();
+  // move prev version to undo list
+  undo_list.push(redo_list.pop());
+  undoing = true;
+  const op = await undo_list[undo_list.length-1];
+  // use last server-related attributes
+  op.fetched = sop.fetched;
+  op.fetchedOp = sop.fetchedOp;
+  op.lasteditid = sop.lasteditid;
+  await op.store();
+  // switch to this op
+  await makeSelectedOperation(op.ID);
+  undoing = false;
+  return true;
+}
+
+export function undoable() {
+  return undo_list.length > 1;
+}
+
+export function redoable() {
+  return redo_list.length > 0;
+}
+
+function onChange() {
+  if (undoing) return;
+  const sop = getSelectedOperation();
+  // stack a copy of the current version
+  undo_list.push(WasabeeOp.load(sop.ID));
+  if (undo_list.length > constants.UNDO_HISTORY_SIZE) undo_list.shift();
+  // drop the undone list
+  redo_list = [];
+}


### PR DESCRIPTION
# Ability to undo/redo recent changes

* arbitrary 100 history size
* any change flush the redo list
* history is lost when selecting a different op, and on page refresh
* shortcut using [accesskey](https://developer.mozilla.org/fr/docs/Web/HTML/Global_attributes/accesskey)
    * alt+z/y chrome
    * shift+alt+z/y firefox
    * macOS (any): ctrl+alt+z/y

Dev notes:
 * store a copy of the current whenever the `op.update` method is called (atomic change or batch changes end)
 * download/sync (and merge) the current op is considered as a single change
 * the local attributes related to the fetch data is maintain across undo/redo. Therefore after a sync, any undo will result to an up to date OP with respect to the server (consecutive sync won't trigger the usual loop)
 * on op select (different from the current op), the copies are dropped, and a copy of the newly selected op is stored