### PR TITLE
Fix references to symbols in statics.

### DIFF
--- a/src/code/dialogs/assignDialog.js
+++ b/src/code/dialogs/assignDialog.js
@@ -39,7 +39,7 @@ const AssignDialog = WDialog.extend({
       width: "auto",
       dialogClass: "assign",
       buttons: buttons,
-      id: statics.assign,
+      id: statics.dialogNames.assign,
       autofocus: true,
     });
   },

--- a/src/code/dialogs/authDialog.js
+++ b/src/code/dialogs/authDialog.js
@@ -174,7 +174,7 @@ const AuthDialog = WDialog.extend({
       width: "auto",
       dialogClass: "auth",
       buttons: buttons,
-      id: statics.mustauth,
+      id: statics.dialogNames.mustauth,
     });
   },
 

--- a/src/code/static.ts
+++ b/src/code/static.ts
@@ -47,6 +47,11 @@ const dialogNames = {
   starburst: "wasabee-starburst",
   savelinks: "wasabee-savelinks",
   settings: "wasabee-settings",
+  fanfield: "wasabee-fanfield",
+  skinDialog: "wasabee-settings-skins",
+  setComment: "wasabee-comment",
+  trawl: "wasabee-trawl",
+  manageTeam: "wasabee-manageteam",
 };
 
 export const constants = {


### PR DESCRIPTION
A recent refactoring of statics incorrectly updated references for two symbols. Additionally, there were existing references that never existed which have been added.