### PR TITLE
Kown blockers usage as opt-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wasabee-iitc",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wasabee-iitc",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasabee-iitc",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "IITC Plugin for Wasabee Project",
   "main": "gulpfile.js",
   "private": true,

--- a/src/code/crosslinks.ts
+++ b/src/code/crosslinks.ts
@@ -131,10 +131,15 @@ export async function checkAllLinks() {
     return;
   }
 
+  const useKnownBlockers =
+    localStorage[
+      window.plugin.wasabee.static.constants.BLOCKERS_USE_IN_CROSSLINKS
+    ] === "true";
+
   // re-test known data (link/link, link/blocker)
   const blockers = await WasabeeBlocker.getAll(operation);
   for (const l of operation.links) {
-    l.blocked = testBlocked(l, operation, blockers);
+    if (useKnownBlockers) l.blocked = testBlocked(l, operation, blockers);
     l.selfBlocked = testSelfBlock(l, operation);
   }
   for (const b of blockers) {

--- a/src/code/crosslinks.ts
+++ b/src/code/crosslinks.ts
@@ -140,6 +140,7 @@ export async function checkAllLinks() {
   const blockers = await WasabeeBlocker.getAll(operation);
   for (const l of operation.links) {
     if (useKnownBlockers) l.blocked = testBlocked(l, operation, blockers);
+    else l.blocked = false;
     l.selfBlocked = testSelfBlock(l, operation);
   }
   for (const b of blockers) {

--- a/src/code/dialogs/blockersList.js
+++ b/src/code/dialogs/blockersList.js
@@ -2,7 +2,7 @@ import { WDialog } from "../leafletClasses";
 import Sortable from "../sortable";
 import { getSelectedOperation } from "../selectedOp";
 import {
-  listenForAddedPortals,
+  // listenForAddedPortals,
   listenForPortalDetails,
   loadBlockerFaked,
 } from "../ui/portal";
@@ -34,7 +34,7 @@ const BlockerList = WDialog.extend({
     window.map.on("wasabee:crosslinks:update", this.update, this);
     window.map.on("wasabee:crosslinks:done", this.update, this);
 
-    window.addHook("portalAdded", listenForAddedPortals);
+    // window.addHook("portalAdded", listenForAddedPortals);
     window.addHook("portalDetailLoaded", listenForPortalDetails);
     this._displayDialog();
   },
@@ -45,7 +45,7 @@ const BlockerList = WDialog.extend({
     window.map.off("wasabee:crosslinks:update", this.update, this);
     window.map.off("wasabee:crosslinks:done", this.update, this);
 
-    window.removeHook("portalAdded", listenForAddedPortals);
+    // window.removeHook("portalAdded", listenForAddedPortals);
     window.removeHook("portalDetailLoaded", listenForPortalDetails);
   },
 

--- a/src/code/dialogs/checklist.js
+++ b/src/code/dialogs/checklist.js
@@ -6,7 +6,7 @@ import StateDialog from "./stateDialog";
 import SetCommentDialog from "./setCommentDialog";
 import MarkerChangeDialog from "./markerChangeDialog";
 import {
-  listenForAddedPortals,
+  // listenForAddedPortals,
   listenForPortalDetails,
   loadFaked,
 } from "../ui/portal";
@@ -39,7 +39,7 @@ const OperationChecklistDialog = WDialog.extend({
     window.map.on("wasabee:op:select wasabee:op:change", this.update, this);
     window.map.on("wasabee:filter", this.update, this);
 
-    window.addHook("portalAdded", listenForAddedPortals);
+    // window.addHook("portalAdded", listenForAddedPortals);
     window.addHook("portalDetailsLoaded", listenForPortalDetails);
 
     this._displayDialog();
@@ -50,7 +50,7 @@ const OperationChecklistDialog = WDialog.extend({
     window.map.off("wasabee:op:select wasabee:op:change", this.update, this);
     window.map.off("wasabee:filter", this.update, this);
 
-    window.removeHook("portalAdded", listenForAddedPortals);
+    // window.removeHook("portalAdded", listenForAddedPortals);
     window.removeHook("portalDetailsLoaded", listenForPortalDetails);
   },
 

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -167,7 +167,7 @@ const SettingsDialog = WDialog.extend({
 
     this._addCheckBox(
       container,
-      "Blockers show all known blockers", // TODO wX
+      wX("dialog.settings.show_known_blockers"),
       "wasabee-setting-blockers-show-all",
       statics.constants.BLOCKERS_SHOW_ALL,
       null,
@@ -176,7 +176,7 @@ const SettingsDialog = WDialog.extend({
 
     this._addCheckBox(
       container,
-      "Use known blockers in cross link checks", // TODO wX
+      wX("dialog.settings.use_blockers_in_crosslink"),
       "wasabee-setting-blockers-use-in-crosslinks",
       statics.constants.BLOCKERS_USE_IN_CROSSLINKS,
       null,

--- a/src/code/dialogs/settingsDialog.js
+++ b/src/code/dialogs/settingsDialog.js
@@ -165,6 +165,24 @@ const SettingsDialog = WDialog.extend({
       injectPortalsAsPlaceholders
     );
 
+    this._addCheckBox(
+      container,
+      "Blockers show all known blockers", // TODO wX
+      "wasabee-setting-blockers-show-all",
+      statics.constants.BLOCKERS_SHOW_ALL,
+      null,
+      false
+    );
+
+    this._addCheckBox(
+      container,
+      "Use known blockers in cross link checks", // TODO wX
+      "wasabee-setting-blockers-use-in-crosslinks",
+      statics.constants.BLOCKERS_USE_IN_CROSSLINKS,
+      null,
+      false
+    );
+
     const serverInfo = L.DomUtil.create("button", "server", container);
     serverInfo.textContent = wX("WSERVER", { url: GetWasabeeServer() });
     serverInfo.href = "#";

--- a/src/code/init.ts
+++ b/src/code/init.ts
@@ -21,7 +21,7 @@ import { onMessage as fbMessageHandler } from "./firebase/event";
 import { postToFirebase } from "./firebase/logger";
 import { initWasabeeD } from "./wd";
 import { sendLocation } from "./uiCommands";
-import { listenForPortalDetails } from "./ui/portal";
+import { listenForAddedPortals, listenForPortalDetails } from "./ui/portal";
 import { initSkin, changeSkin } from "./skin";
 import { WPane } from "./leafletClasses";
 import OperationChecklist from "./dialogs/checklist";
@@ -145,6 +145,7 @@ window.plugin.wasabee.init = async () => {
     window.map.fire("wasabee:agentlocations");
   });
 
+  window.addHook("portalAdded", listenForAddedPortals);
   window.addHook("portalDetailsUpdated", (e) => {
     listenForPortalDetails({
       success: true,

--- a/src/code/map/blocker.ts
+++ b/src/code/map/blocker.ts
@@ -27,6 +27,7 @@ export class WLBlockerLayer extends L.FeatureGroup {
   onAdd(map: L.Map): this {
     super.onAdd(map);
     map.on("wasabee:op:select", this.update, this);
+    map.on("wasabee:crosslinks:update", this.update, this);
     map.on("wasabee:crosslinks:done", this.update, this);
     this.update();
     return this;
@@ -35,6 +36,7 @@ export class WLBlockerLayer extends L.FeatureGroup {
   onRemove(map: L.Map): this {
     super.onRemove(map);
     map.off("wasabee:op:select", this.update, this);
+    map.off("wasabee:crosslinks:update", this.update, this);
     map.off("wasabee:crosslinks:done", this.update, this);
     return this;
   }

--- a/src/code/map/blocker.ts
+++ b/src/code/map/blocker.ts
@@ -58,13 +58,29 @@ export class WLBlockerLayer extends L.FeatureGroup {
       for (const key in this.blockers) {
         this.removeLayer(this.blockers[key]);
       }
+      const showAll =
+        localStorage[
+          window.plugin.wasabee.static.constants.BLOCKERS_SHOW_ALL
+        ] === "true";
+
+      const toDisplay = new Set();
+      if (!showAll) {
+        for (const guid in window.links) {
+          const link = window.links[guid];
+          const from = link.options.data.oGuid;
+          const to = link.options.data.dGuid;
+          toDisplay.add(from + to);
+        }
+      }
+
       this.blockers = {};
       for (const blocker of blockers) {
-        this.blockers[blocker.fromPortal.id + blocker.toPortal.id] =
-          L.geodesicPolyline(
-            [blocker.fromPortal.latLng, blocker.toPortal.latLng],
-            blockerStyle
-          ).addTo(this);
+        const key = blocker.fromPortal.id + blocker.toPortal.id;
+        if (!showAll && !toDisplay.has(key)) continue;
+        this.blockers[key] = L.geodesicPolyline(
+          [blocker.fromPortal.latLng, blocker.toPortal.latLng],
+          blockerStyle
+        ).addTo(this);
       }
     });
     for (const key in this.blocked) {

--- a/src/code/static.ts
+++ b/src/code/static.ts
@@ -97,6 +97,8 @@ export const constants = {
   FIREBASE_DISABLE: "wasabee-firebase",
   UNDO_HISTORY_SIZE: 100,
   POPULATE_OPPORTALS: "wasabee-populate-opportals",
+  BLOCKERS_SHOW_ALL: "wasabee-blockers-show-all",
+  BLOCKERS_USE_IN_CROSSLINKS: "wasabee-blockers-use-in-crosslinks",
 };
 
 const defaultOperationColor = "orange";

--- a/src/code/translations/English.json
+++ b/src/code/translations/English.json
@@ -194,6 +194,8 @@
   "dialog.setcomment.portal_hardness": "Hardness",
   "dialog.settings.disable_live_updates": "Disable live updates",
   "dialog.settings.populate_opportals": "Populate map with op portals",
+  "dialog.settings.show_known_blockers": "Show all known blockers",
+  "dialog.settings.use_blockers_in_crosslink": "Use known blockers in cross link checks",
   "dialog.team_list.load_wd_keys": "Load W-D Keys",
   "dialog.team_list.share_wd_keys": "Share W-D Keys",
   "dialog.team_manage.join_link": "Join Link",


### PR DESCRIPTION
Remove outdated blockers more aggressively wrt map state.
Add opt-in to display invisible (not rendered) blockers and use blockers in crosslink check (instead of only visible links). 